### PR TITLE
metrics.flush() needs to be awaited (or returned)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const myFunc = async () => {
   metrics.putMetric("ProcessingLatency", 100, Unit.Milliseconds);
   metrics.setProperty("RequestId", "422b1569-16f6-4a03-b8f0-fe3fd9b100f8");
   // ...
-  metrics.flush();
+  await metrics.flush();
 };
 
 await myFunc();


### PR DESCRIPTION
In the README you're calling `metrics.flush()` without awaiting it. This means that execution of subsequent functions will continue even though `metrics.flush()` may not have completed. It also means that exceptions won't correctly be captured by the async block.

In your tests you're correctly awaiting it, but if ppl use this in their code as currently documented in the README they could run into some tricky to debug concurrency problems (and potential unhandled promises being thrown)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
