### PR TITLE
fix: unhandled TCP error in AgentSink constructor and TcpClient sendM…

### DIFF
--- a/src/sinks/AgentSink.ts
+++ b/src/sinks/AgentSink.ts
@@ -102,6 +102,8 @@ export class AgentSink implements ISink {
 
   private getSocketClient(endpoint: IEndpoint): ISocketClient {
     LOG('Getting socket client for connection.', endpoint);
-    return endpoint.protocol === TCP ? new TcpClient(endpoint).connect() : new UdpClient(endpoint);
+    const client = endpoint.protocol === TCP ? new TcpClient(endpoint) : new UdpClient(endpoint);
+    client.warmup();
+    return client;
   }
 }

--- a/src/sinks/__tests__/AgentSink.test.ts
+++ b/src/sinks/__tests__/AgentSink.test.ts
@@ -1,5 +1,6 @@
 import * as faker from 'faker';
 import Configuration from '../../config/Configuration';
+import { MetricsContext } from '../../logger/MetricsContext';
 import { AgentSink } from '../AgentSink';
 
 test('default endpoint is tcp', () => {
@@ -33,4 +34,18 @@ test('can parse udp endpoints', () => {
   expect(sink.endpoint.host).toBe('127.0.0.1');
   // @ts-ignore
   expect(sink.endpoint.port).toBe(1000);
+});
+
+test('handles tcp connection error', async () => {
+  // arrange
+  const noProcessPort = faker.random.number({min: 1000, max: 9999})
+  Configuration.agentEndpoint = `tcp://127.0.0.1:${noProcessPort}`;
+  const context = MetricsContext.empty()
+  const logGroupName = faker.random.word();
+  const sink = new AgentSink(logGroupName);
+
+  // assert
+  return expect(
+    sink.accept(context)
+  ).rejects.toThrowError(/ECONNREFUSED/)
 });

--- a/src/sinks/__tests__/TcpClient.test.ts
+++ b/src/sinks/__tests__/TcpClient.test.ts
@@ -1,0 +1,17 @@
+import * as faker from 'faker'
+import { TcpClient } from '../connections/TcpClient';
+
+test('handles tcp client errors', async () => {
+  // arrange
+  const noProcessPort = faker.random.number({min: 1000, max: 9999})
+  const client = new TcpClient({
+    host: '0.0.0.0',
+    port: noProcessPort,
+    protocol: 'tcp'
+  })
+
+  // assert
+  return expect(
+    client.sendMessage(Buffer.from([]))
+  ).rejects.toThrowError(/ECONNREFUSED/)
+});

--- a/src/sinks/connections/ISocketClient.ts
+++ b/src/sinks/connections/ISocketClient.ts
@@ -14,5 +14,6 @@
  */
 
 export interface ISocketClient {
+  warmup(): Promise<void>;
   sendMessage(message: Buffer): Promise<void>;
 }

--- a/src/sinks/connections/TcpClient.ts
+++ b/src/sinks/connections/TcpClient.ts
@@ -33,8 +33,6 @@ export class TcpClient implements ISocketClient {
       .on('data', data => LOG('TcpClient received data.', data));
   }
 
-  // create the connection as soon as we can, but don't block
-  // we can block on flush if we have to.
   public async warmup() {
     try {
       await this.establishConnection();

--- a/src/sinks/connections/TcpClient.ts
+++ b/src/sinks/connections/TcpClient.ts
@@ -33,24 +33,32 @@ export class TcpClient implements ISocketClient {
       .on('data', data => LOG('TcpClient received data.', data));
   }
 
-  public connect(): TcpClient {
-    // create the connection as soon as we can, but don't block
-    // we can block on flush if we have to.
-    this.establishConnection();
-    return this;
+  // create the connection as soon as we can, but don't block
+  // we can block on flush if we have to.
+  public async warmup() {
+    try {
+      await this.establishConnection();
+    } catch (err) {
+      LOG('Failed to connect', err)
+    }
   }
 
   public async sendMessage(message: Buffer): Promise<void> {
     await this.waitForOpenConnection();
     await new Promise((resolve, reject) => {
-      const wasFlushedToKernel = this.socket.write(message, (err?: Error) => {
+      const onSendError = (err: Error) => {
+        LOG('Failed to write', err);
+        LOG('Socket', this.socket);
+        reject(err);
+      }
+      const wasFlushedToKernel = this.socket
+      .once('error', onSendError)
+      .write(message, (err?: Error) => {
         if (!err) {
           LOG('Write succeeded');
           resolve();
         } else {
-          LOG('Failed to write', err);
-          LOG('Socket', this.socket);
-          reject();
+          onSendError(err)
         }
       });
 
@@ -79,10 +87,10 @@ export class TcpClient implements ISocketClient {
           LOG('TcpClient connected.', this.endpoint);
           resolve();
         })
-        .once('error', () => {
+        .once('error', (e) => {
           this.disconnect('error');
           this.socket.removeListener('connection', resolve);
-          reject();
+          reject(e);
         });
     });
   }

--- a/src/sinks/connections/UdpClient.ts
+++ b/src/sinks/connections/UdpClient.ts
@@ -25,7 +25,12 @@ export class UdpClient implements ISocketClient {
     this.endpoint = endpoint;
   }
 
-  public sendMessage(message: Buffer): Promise<void> {
+  // No warm up for UDP
+  public warmup (): Promise<void> {
+    return Promise.resolve()
+  }
+
+  public async sendMessage(message: Buffer): Promise<void> {
     const client = dgram.createSocket('udp4');
     client.send(message, this.endpoint.port, this.endpoint.host, (error: any) => {
       if (error) {


### PR DESCRIPTION
…essage functions

*Issue #, if available:*

*Description of changes:*

Handles unhandled rejections for Tcp Client.
Improves error messages by passing original error object to `reject` functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
