### PR TITLE
Fix package-lock version error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-embedded-metrics",
-  "version": "0.1.0-beta.1573242639",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* I recently went to install this package and its dependencies and found the [package-lock.json](https://github.com/awslabs/aws-embedded-metrics-node/blob/master/package-lock.json#L3) version was out of sync with the [package.json](https://github.com/awslabs/aws-embedded-metrics-node/blob/master/package.json#L3) version.

This PR fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
