### PR TITLE
Preserve the metricScope function parameter typing using generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Generate CloudWatch Metrics embedded within structured log events. The embedded 
 - **Linking metrics to high cardinality context**
 
   Using the Embedded Metric Format, you will be able to visualize and alarm on custom metrics, but also retain the original, detailed and high-cardinality context which is queryable using [CloudWatch Logs Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html). For example, the library automatically injects environment metadata such as Lambda Function version, EC2 instance and image ids into the structured log event data.
-  
+
 ## Installation
 
 ```
@@ -33,12 +33,12 @@ npm install aws-embedded-metrics
 
 To get a metric logger, you can either decorate your function with a metricScope, or manually create and flush the logger.
 
-Using the metricScope decorator:
+Using the metricScope decorator without function parameters:
 
 ```js
 const { metricScope, Unit } = require("aws-embedded-metrics");
 
-const myFunc = metricScope(metrics => 
+const myFunc = metricScope(metrics =>
   async () => {
     metrics.putDimensions({ Service: "Aggregator" });
     metrics.putMetric("ProcessingLatency", 100, Unit.Milliseconds);
@@ -47,6 +47,22 @@ const myFunc = metricScope(metrics =>
   });
 
 await myFunc();
+```
+
+Using the metricScope decorator with function parameters:
+
+```js
+const { metricScope, Unit } = require("aws-embedded-metrics");
+
+const myFunc = metricScope(metrics =>
+  async (param1: string, param2: number) => {
+    metrics.putDimensions({ Service: "Aggregator" });
+    metrics.putMetric("ProcessingLatency", 100, Unit.Milliseconds);
+    metrics.setProperty("RequestId", "422b1569-16f6-4a03-b8f0-fe3fd9b100f8");
+    // ...
+  });
+
+await myFunc('myParam', 0);
 ```
 
 Manually constructing and flushing the logger:
@@ -73,7 +89,7 @@ If you are running on Lambda, export your function like so:
 ```js
 const { metricScope } = require("aws-embedded-metrics");
 
-const myFunc = metricScope(metrics => 
+const myFunc = metricScope(metrics =>
   async () => {
     // ...
   });
@@ -109,8 +125,8 @@ Adds or updates the value for a given property on this context. This value is no
 
 Requirements:
 - Length 1-255 characters
-    
-Examples: 
+
+Examples:
 ```js
 setProperty("RequestId", "422b1569-16f6-4a03-b8f0-fe3fd9b100f8")
 setProperty("InstanceId", "i-1234567890")
@@ -124,7 +140,7 @@ setProperty("Device", {
 
 Adds a new set of dimensions that will be associated to all metric values.
 
-**WARNING**: Every distinct value will result in a new CloudWatch Metric. 
+**WARNING**: Every distinct value will result in a new CloudWatch Metric.
 If the cardinality of a particular value is expected to be high, you should consider
 using `setProperty` instead.
 
@@ -132,7 +148,7 @@ Requirements:
 - Length 1-255 characters
 - ASCII characters only
 
-Examples: 
+Examples:
 ```js
 putDimensions({ Operation: "Aggregator" })
 putDimensions({ Operation: "Aggregator", DeviceType: "Actuator" })
@@ -142,7 +158,7 @@ putDimensions({ Operation: "Aggregator", DeviceType: "Actuator" })
 
 Explicitly override all dimensions. This will remove the default dimensions.
 
-**WARNING**: Every distinct value will result in a new CloudWatch Metric. 
+**WARNING**: Every distinct value will result in a new CloudWatch Metric.
 If the cardinality of a particular value is expected to be high, you should consider
 using `setProperty` instead.
 
@@ -206,7 +222,7 @@ Requirements:
 - Name Length 1-255 characters
 - Name must be ASCII characters only
 
-Example: 
+Example:
 
 ```js
 // in process

--- a/src/logger/MetricScope.ts
+++ b/src/logger/MetricScope.ts
@@ -20,10 +20,10 @@ import { createMetricsLogger } from './MetricsLoggerFactory';
 /**
  * An asynchronous wrapper that provides a metrics instance.
  */
-const metricScope = <T>(
-  handler: (m: MetricsLogger) => (...args: any[]) => T | Promise<T>,
-): ((...args: any[]) => Promise<T | undefined>) => {
-  const wrappedHandler = async (...args: any[]): Promise<T | undefined> => {
+const metricScope = <T, U extends readonly unknown[]>(
+  handler: (m: MetricsLogger) => (...args: U) => T | Promise<T>,
+): ((...args: U) => Promise<T | undefined>) => {
+  const wrappedHandler = async (...args: U): Promise<T | undefined> => {
     const metrics = createMetricsLogger();
     let exception;
     try {

--- a/src/logger/__tests__/MetricScope.test.ts
+++ b/src/logger/__tests__/MetricScope.test.ts
@@ -12,7 +12,7 @@ test('async scope executes handler function', async () => {
   // arrange
   let wasInvoked = false;
 
-  const handler = metricScope(metrics => async (evt: any) => {
+  const handler = metricScope(metrics => async () => {
     await sleep(100);
     wasInvoked = true;
   });
@@ -28,7 +28,7 @@ test('sync scope executes handler function', async () => {
   // arrange
   let a = false;
 
-  const handler = metricScope(metrics => (evt: any) => {
+  const handler = metricScope(metrics => () => {
     a = true;
   });
 
@@ -43,19 +43,22 @@ test('sync scope executes handler function', async () => {
 
 test('async scope passes arguments', async () => {
   // arrange
-  let arg = false;
+  let arg1 = false;
+  let arg2 = '';
 
-  const handler = metricScope(metrics => async (input: any) => {
-    arg = input;
+  const handler = metricScope(metrics => async (input1: boolean, input2: string) => {
+    arg1 = input1;
+    arg2 = input2;
   });
 
   // act
   // the customer can pass in a synchronous function, but we will still return
   // an async function back to the Lambda caller
-  await handler(true);
+  await handler(true, 'success');
 
   // assert
-  expect(arg).toBe(true);
+  expect(arg1).toBe(true);
+  expect(arg2).toBe('success');
 });
 
 test('async scope returns child function return value', async () => {
@@ -77,19 +80,22 @@ test('async scope returns child function return value', async () => {
 
 test('sync scope passes arguments', async () => {
   // arrange
-  let arg = false;
+  let arg1 = false;
+  let arg2 = '';
 
-  const handler = metricScope(metrics => (input: any) => {
-    arg = input;
+  const handler = metricScope(metrics => (input1: boolean, input2: string) => {
+    arg1 = input1;
+    arg2 = input2;
   });
 
   // act
   // the customer can pass in a synchronous function, but we will still return
   // an async function back to the Lambda caller
-  await handler(true);
+  await handler(true, 'success');
 
   // assert
-  expect(arg).toBe(true);
+  expect(arg1).toBe(true);
+  expect(arg2).toBe('success');
 });
 
 test('sync scope returns child function return value', async () => {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
When trying to use the [metricScope](https://github.com/awslabs/aws-embedded-metrics-node/blob/master/src/logger/MetricScope.ts) with function parameters, I noticed that the input arguments were being cast as `any[]`.

This is dangerous and can lead to cases where users are able to declare something like this:

```typescript
const myFunc = metricScope(metrics => async (param1: string, param2: number) => { ... });
```

but then (accidentally) call it like this which can cause runtime errors:

```
myFunc(0, 'myParam'); // Ahhhhh I accidentally put the parameters in the wrong order!!
```

This PR fixes this by preserving the `args` typing information via using generics and having the generic extend `readonly unknown[]` which is the immutable, type safe way to do this.

I updated existing tests to account for this (since some of them, by design, wouldnt compile with this change) as well as updated the `README.md` to be more clear how to use the `metricScope` when you want your function to have arguments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
