### PR TITLE
fix(#15): preserve the logger context across flushes

### DIFF
--- a/src/logger/MetricsLogger.ts
+++ b/src/logger/MetricsLogger.ts
@@ -48,7 +48,7 @@ export class MetricsLogger {
 
     // accept and reset the context
     sink.accept(this.context);
-    this.context = MetricsContext.empty();
+    this.context = this.context.createCopyWithContext();
   }
 
   /**


### PR DESCRIPTION
Closes #15