### PR TITLE
#17 generic agent support

### DIFF
--- a/src/environment/DefaultEnvironment.ts
+++ b/src/environment/DefaultEnvironment.ts
@@ -43,6 +43,12 @@ export class DefaultEnvironment implements IEnvironment {
   }
 
   public getLogGroupName(): string {
+    // if the caller explicitly overrides logGroupName to 
+    // be empty, we should honor that rather than providing 
+    // the default behavior.
+    if (config.logGroupName === "") {
+      return "";
+    }
     return config.logGroupName ? config.logGroupName : `${this.getName()}-metrics`;
   }
 

--- a/src/environment/__tests__/DefaultEnvironment.test.ts
+++ b/src/environment/__tests__/DefaultEnvironment.test.ts
@@ -88,6 +88,18 @@ test('getLogGroupName() returns <ServiceName>-metrics if not configured', () => 
   expect(result).toBe(`${serviceName}-metrics`);
 });
 
+test('getLogGroupName() returns empty if explicitly set to empty', () => {
+  // arrange
+  config.logGroupName = "";
+  const env = new DefaultEnvironment();
+
+  // act
+  const result = env.getLogGroupName();
+
+  // assert
+  expect(result).toBe(``);
+});
+
 test('getSink() creates an AgentSink', () => {
   // arrange
   const expectedSink = 'AgentSink';

--- a/src/sinks/AgentSink.ts
+++ b/src/sinks/AgentSink.ts
@@ -89,7 +89,10 @@ export class AgentSink implements ISink {
   }
 
   public async accept(context: MetricsContext): Promise<void> {
-    context.meta.LogGroupName = this.logGroupName;
+    if (this.logGroupName) {
+      context.meta.LogGroupName = this.logGroupName;
+    }
+   
     if (this.logStreamName) {
       context.meta.LogStreamName = this.logStreamName;
     }


### PR DESCRIPTION
Closes #17 

Some agents (such as Fluent-Bit) handle LogGroup configuration in the agent directly. By allowing the LogGroup to be optional, we provide better support for these scenarios without including some arbitrary and incorrect LogGroup name in the payload