### PR TITLE
Set MAX_DIMENSIONS=9

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -14,6 +14,6 @@
  */
 
 export enum Constants {
-  MAX_DIMENSIONS = 10,
+  MAX_DIMENSIONS = 9,
   DEFAULT_NAMESPACE = 'aws-embedded-metrics',
 }

--- a/src/serializers/__tests__/LogSerializer.test.ts
+++ b/src/serializers/__tests__/LogSerializer.test.ts
@@ -21,11 +21,11 @@ test('serializes dimensions', () => {
   assertJsonEquality(resultJson, expected);
 });
 
-test('cannot serialize more than 10 dimensions', () => {
+test('cannot serialize more than 9 dimensions', () => {
   // arrange
   const dimensions: any = {};
   const dimensionPointers = [];
-  const allowedDimensions = 10;
+  const allowedDimensions = 9;
   const dimensionsToAdd = 11;
   for (let i = 0; i < dimensionsToAdd; i++) {
     const expectedKey = `${i}`;


### PR DESCRIPTION
The backend will fail to parse entries with more than 9 dimensions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
