### PR TITLE
Fixes environment override typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ const { Configuration } = require("aws-embedded-metrics");
 Configuration.environmentOverride = "Local";
 
 // environment
-AWS_EMF_AGENT_ENDPOINT=Local
+AWS_EMF_ENVIRONMENT=Local
 ```
 
 **EnableDebugLogging**: Enable debug logging for the library. If the library is not behaving as expected, you can set this to true to log to console.


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Currently, the README says that you can override the environment using a `AWS_EMF_AGENT_ENDPOINT` environment variable.

This is a typo and it is meant to be `AWS_EMF_ENVIRONMENT` as specified [here](https://github.com/awslabs/aws-embedded-metrics-node/blob/f718aac9bf08ada0e1c7c3ebf1857273d7f1e091/src/config/EnvironmentConfigurationProvider.ts#L28).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
