### PR TITLE
add ECS environment with FireLens support

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -28,3 +28,57 @@ Run the example:
 ```
 ./examples/agent/run.sh
 ```
+
+## FireLens on ECS
+
+You can deploy the example by running the following:
+
+```sh
+# create an ECR repository for the example image
+aws ecr create-repository --repository-name <image-name> --region <region>
+
+# create an S3 bucket for the Fluent-Bit configuration
+aws s3api create-bucket --bucket <bucket-name> --region <region>
+
+# create ECS cluster
+# create ECS task definition
+# create ECS service
+
+# deploy
+./examples/ecs-firelens/publish.sh \
+  <account-id> \
+  <region> \
+  <image-name> \
+  <s3-bucket> \
+  <ecs-cluster-name> \
+  <ecs-task-family> \
+  <ecs-service-name>
+```
+
+### Example Metrics
+
+```json
+{
+  "_aws": {
+    "Timestamp": 1583902595342,
+    "CloudWatchMetrics": [
+      {
+        "Dimensions": [[ "ServiceName", "ServiceType" ]],
+        "Metrics": [{ "Name": "ProcessingTime", "Unit": "Milliseconds" }],
+        "Namespace": "aws-embedded-metrics"
+      }
+    ]
+  },
+  "ServiceName": "example",
+  "ServiceType": "AWS::ECS::Container",
+  "Method": "GET",
+  "Url": "/test",
+  "containerId": "702e4bcf1345",
+  "createdAt": "2020-03-11T04:54:24.981207801Z",
+  "startedAt": "2020-03-11T04:54:25.594413051Z",
+  "image": "<account-id>.dkr.ecr.<region>.amazonaws.com/emf-examples:latest",
+  "cluster": "emf-example",
+  "taskArn": "arn:aws:ecs:<region>:<account-id>:task/2fe946f6-8a2e-41a4-8fec-c4983bad8f74",
+  "ProcessingTime": 5
+}
+```

--- a/examples/ecs-firelens/.gitignore
+++ b/examples/ecs-firelens/.gitignore
@@ -1,0 +1,1 @@
+container-definitions.json

--- a/examples/ecs-firelens/Dockerfile
+++ b/examples/ecs-firelens/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:10.16.0-alpine AS base
+RUN mkdir -p /app/src
+WORKDIR /app/src
+
+COPY package.json ./
+# install packages but copy the local version of the package in directly
+RUN npm i && rm -rf node_modules/aws-embedded-metrics
+COPY node_modules/aws-embedded-metrics ./node_modules/aws-embedded-metrics
+
+# copy the source files over
+COPY . .
+
+CMD [ "node", "app" ]

--- a/examples/ecs-firelens/app.js
+++ b/examples/ecs-firelens/app.js
@@ -1,0 +1,23 @@
+const Koa = require('koa');
+const app = new Koa();
+
+const { metricScope, Unit } = require('aws-embedded-metrics');
+
+app.use(
+  metricScope(metrics => async (ctx, next) => {
+    const start = Date.now();
+
+    await next();
+
+    ctx.body = `Hello World ... ${ctx.method} ${ctx.url}\n`;
+
+    metrics.setProperty('Method', ctx.method);
+    metrics.setProperty('Url', ctx.url);
+    metrics.putMetric('ProcessingTime', Date.now() - start, Unit.Milliseconds);
+
+    // send application logs to stdout, FireLens will send this to a different LogGroup
+    console.log('Completed Request');
+  }),
+);
+
+app.listen(3000);

--- a/examples/ecs-firelens/container-definitions.template.json
+++ b/examples/ecs-firelens/container-definitions.template.json
@@ -1,0 +1,31 @@
+[
+  {
+    "name": "example",
+    "image": "<account-id>.dkr.ecr.<region>.amazonaws.com/<image-name>:latest",
+    "portMappings": [{ "containerPort": 3000, "protocol": "tcp" }],
+    "essential": true,
+    "logConfiguration": {
+      "logDriver": "awsfirelens",
+      "options": {
+        "Name": "cloudwatch",
+        "region": "<region>",
+        "log_group_name": "aws-emf-ecs-firelens-example-logs",
+        "auto_create_group": "true",
+        "log_stream_prefix": "from-fluent-bit"
+      }
+    },
+    "links": ["fluent-bit"]
+  },
+  {
+    "name": "fluent-bit",
+    "image": "906394416424.dkr.ecr.<region>.amazonaws.com/aws-for-fluent-bit:latest",
+    "essential": true,
+    "firelensConfiguration": {
+      "type": "fluentbit",
+      "options": {
+        "config-file-type": "s3",
+        "config-file-value": "arn:aws:s3:::<s3-bucket>/fluent-bit.conf"
+      }
+    }
+  }
+]

--- a/examples/ecs-firelens/fluent-bit.conf
+++ b/examples/ecs-firelens/fluent-bit.conf
@@ -1,0 +1,24 @@
+# TCP input used for EMF payloads
+[INPUT]
+    Name        tcp
+    Listen      0.0.0.0
+    Port        25888
+    Chunk_Size  32
+    Buffer_Size 64
+    Format      none
+    Tag         emf-${HOSTNAME}
+    # This tag is used by the output plugin to determine the LogStream
+    # including the HOSTNAME is a way to increase the number of LogStreams
+    # proportional to the number of instances. The maximum throughput on a
+    # single LogStream is 5 MB/s (max 1 MB at max 5 TPS).
+
+# Output for EMF over TCP -> CloudWatch
+[OUTPUT]
+    Name                cloudwatch
+    Match               emf-*
+    region              us-east-1
+    log_key             log
+    log_group_name      aws-emf-ecs-firelens-example-metrics
+    log_stream_prefix   from-fluent-bit-
+    auto_create_group   true
+    log_format          json/emf

--- a/examples/ecs-firelens/package-lock.json
+++ b/examples/ecs-firelens/package-lock.json
@@ -1,0 +1,307 @@
+{
+  "name": "ecs-firelens",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+    },
+    "aws-embedded-metrics": {
+      "version": "1.1.0-rc1",
+      "resolved": "https://registry.npmjs.org/aws-embedded-metrics/-/aws-embedded-metrics-1.1.0-rc1.tgz",
+      "integrity": "sha512-uOzjw3U3XEQYoKQVvLud/18msUhkSjytGuVFiIwE4tFfcbOi837iKbyNgs+RO0bFE9zf6DOPjWwMwym+6wtO+g=="
+    },
+    "cache-content-type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
+      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
+      "requires": {
+        "mime-types": "^2.1.18",
+        "ylru": "^1.2.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookies": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
+      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
+      "requires": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "error-inject": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
+      "integrity": "sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "http-assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.4.1.tgz",
+      "integrity": "sha512-rdw7q6GTlibqVVbXr0CKelfV5iY8G2HqEUkhSk297BMbSpSL8crXC+9rjKoMcZZEsksX30le6f/4ul4E28gegw==",
+      "requires": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.7.2"
+      }
+    },
+    "http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw=="
+    },
+    "keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "requires": {
+        "tsscmp": "1.0.6"
+      }
+    },
+    "koa": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.11.0.tgz",
+      "integrity": "sha512-EpR9dElBTDlaDgyhDMiLkXrPwp6ZqgAIBvhhmxQ9XN4TFgW+gEz6tkcsNI6BnUbUftrKDjVFj4lW2/J2aNBMMA==",
+      "requires": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.8.0",
+        "debug": "~3.1.0",
+        "delegates": "^1.0.0",
+        "depd": "^1.1.2",
+        "destroy": "^1.0.4",
+        "encodeurl": "^1.0.2",
+        "error-inject": "^1.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^1.2.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      }
+    },
+    "koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
+    },
+    "koa-convert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz",
+      "integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
+      "requires": {
+        "co": "^4.6.0",
+        "koa-compose": "^3.0.0"
+      },
+      "dependencies": {
+        "koa-compose": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
+          "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
+          "requires": {
+            "any-promise": "^1.1.0"
+          }
+        }
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "mime-db": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "requires": {
+        "mime-db": "1.43.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "only": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q="
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "ylru": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.2.1.tgz",
+      "integrity": "sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ=="
+    }
+  }
+}

--- a/examples/ecs-firelens/package.json
+++ b/examples/ecs-firelens/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ecs-firelens",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "serve-local": "AWS_EMF_ENVIRONMENT=Local node app"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "aws-embedded-metrics": "^1.1.0-rc1",
+    "koa": "^2.11.0"
+  }
+}

--- a/examples/ecs-firelens/publish.sh
+++ b/examples/ecs-firelens/publish.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Usage:
+#   ./examples/ecs-firelens/publish.sh \
+#     <account-id> \
+#     <region> \
+#     <image-name> \
+#     <s3-bucket> \
+#     <ecs-cluster-name> \
+#     <ecs-task-family> \
+#     <ecs-service-name>
+
+rootdir=$(git rev-parse --show-toplevel)
+
+ACCOUNT_ID=$1
+REGION=$2
+IMAGE_NAME=$3 # emf-ecs-firelens
+FLUENT_BIT_S3_CONFIG_BUCKET=$4 # aws-emf-ecs-firelens-configurations
+CLUSTER_NAME=$5 # emf-example
+ECS_TASK_FAMILY=$6 # aws-emf-ecs-koa-example
+ECS_SERVICE_NAME=$7 # aws-emf-ecs-firelens-ec2
+
+LIB_PATH=$rootdir
+EXAMPLE_DIR=$rootdir/examples/ecs-firelens
+NODE_MODULES_PATH=$EXAMPLE_DIR/node_modules
+ECR_REMOTE=$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/$IMAGE_NAME
+
+function check_exit() {
+    last_exit_code=$?
+    if [ $last_exit_code -ne 0 ]; 
+    then 
+        echo "Last command failed with exit code: $last_exit_code."
+        echo "Exiting."
+        exit $last_exit_code; 
+    fi
+}
+
+echo 'BUILDING THE LOCAL PROJECT'
+pushd $rootdir
+npm i && npm run build
+check_exit
+popd
+
+pushd $EXAMPLE_DIR
+pwd
+
+echo 'COPYING LOCAL PROJECT TO EXAMPLE node_modules'
+rm -rf $NODE_MODULES_PATH/aws-embedded-metrics
+cp -r $LIB_PATH/lib $NODE_MODULES_PATH/aws-embedded-metrics
+
+echo 'UPDATING CONTAINER DEFINITIONS'
+sed "s/<account-id>/$ACCOUNT_ID/g" $EXAMPLE_DIR/container-definitions.template.json \
+| sed "s/<region>/$REGION/g" \
+| sed "s/<s3-bucket>/$FLUENT_BIT_S3_CONFIG_BUCKET/g" \
+| sed "s/<image-name>/$IMAGE_NAME/g" \
+> $EXAMPLE_DIR/container-definitions.json
+check_exit
+
+echo 'PUSHING FLUENT BIT CONFIG TO S3'
+aws s3 cp fluent-bit.conf s3://$FLUENT_BIT_S3_CONFIG_BUCKET --region $REGION
+check_exit
+
+echo 'BUILDING THE EXAMPLE DOCKER IMAGE'
+`aws ecr get-login --no-include-email --region $REGION`
+docker build . -t $IMAGE_NAME:latest
+check_exit
+
+echo 'PUSHING THE EXAMPLE DOCKER IMAGE TO ECR'
+imageid=$(docker images -q $IMAGE_NAME:latest)
+docker tag $imageid $ECR_REMOTE
+docker push $ECR_REMOTE
+check_exit
+
+echo 'UPDATING THE ECS SERVICE'
+aws ecs update-service \
+  --region $REGION \
+  --cluster $CLUSTER_NAME \
+  --service $ECS_SERVICE_NAME \
+  --force-new-deployment \
+  --task-definition $(aws ecs register-task-definition \
+                        --network-mode bridge \
+                        --requires-compatibilities EC2 \
+                        --task-role arn:aws:iam::$ACCOUNT_ID:role/ecsTaskExecutionRole \
+                        --execution-role-arn "arn:aws:iam::$ACCOUNT_ID:role/ecsTaskExecutionRole" \
+                        --region $REGION \
+                        --memory 256 \
+                        --cpu '1 vcpu' \
+                        --family $ECS_TASK_FAMILY \
+                        --container-definitions "$(cat container-definitions.json)" \
+                    | jq --raw-output '.taskDefinition.taskDefinitionArn' | awk -F '/' '{ print $2 }')
+
+popd

--- a/package-lock.json
+++ b/package-lock.json
@@ -532,6 +532,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -585,9 +591,9 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
     "@types/node": {
@@ -618,12 +624,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.10.0.tgz",
-      "integrity": "sha512-rT51fNLW0u3fnDGnAHVC5nu+Das+y2CpW10yqvf6/j5xbuUV3FxA3mBaIbM24CXODXjbgUznNb4Kg9XZOUxKAw==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.23.0.tgz",
+      "integrity": "sha512-8iA4FvRsz8qTjR0L/nK9RcRUN3QtIHQiOm69FzV7WS3SE+7P7DyGGwh3k4UNR2JBbk+Ej2Io+jLAaqKibNhmtw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.10.0",
+        "@typescript-eslint/experimental-utils": "2.23.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -631,39 +637,39 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.10.0.tgz",
-      "integrity": "sha512-FZhWq6hWWZBP76aZ7bkrfzTMP31CCefVIImrwP3giPLcoXocmLTmr92NLZxuIcTL4GTEOE33jQMWy9PwelL+yQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.23.0.tgz",
+      "integrity": "sha512-OswxY59RcXH3NNPmq+4Kis2CYZPurRU6mG5xPcn24CjFyfdVli5mySwZz/g/xDbJXgDsYqNGq7enV0IziWGXVQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.10.0",
+        "@typescript-eslint/typescript-estree": "2.23.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.10.0.tgz",
-      "integrity": "sha512-wQNiBokcP5ZsTuB+i4BlmVWq6o+oAhd8en2eSm/EE9m7BgZUIfEeYFd6z3S+T7bgNuloeiHA1/cevvbBDLr98g==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.23.0.tgz",
+      "integrity": "sha512-k61pn/Nepk43qa1oLMiyqApC6x5eP5ddPz6VUYXCAuXxbmRLqkPYzkFRKl42ltxzB2luvejlVncrEpflgQoSUg==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.10.0",
-        "@typescript-eslint/typescript-estree": "2.10.0",
+        "@typescript-eslint/experimental-utils": "2.23.0",
+        "@typescript-eslint/typescript-estree": "2.23.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.10.0.tgz",
-      "integrity": "sha512-oOYnplddQNm/LGVkqbkAwx4TIBuuZ36cAQq9v3nFIU9FmhemHuVzAesMSXNQDdAzCa5bFgCrfD3JWhYVKlRN2g==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.23.0.tgz",
+      "integrity": "sha512-pmf7IlmvXdlEXvE/JWNNJpEvwBV59wtJqA8MLAxMKLXNKVRC3HZBXR/SlZLPWTCcwOSg9IM7GeRSV3SIerGVqw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "eslint-visitor-keys": "^1.1.0",
         "glob": "^7.1.6",
         "is-glob": "^4.0.1",
-        "lodash.unescape": "4.0.1",
+        "lodash": "^4.17.15",
         "semver": "^6.3.0",
         "tsutils": "^3.17.1"
       },
@@ -736,9 +742,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
     "acorn-walk": {
@@ -1746,9 +1752,9 @@
       }
     },
     "eslint": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.7.2.tgz",
-      "integrity": "sha512-qMlSWJaCSxDFr8fBPvJM9kJwbazrhNcBU3+DszDW1OlEwKBBRWsJc7NJFelvwQpanHCR14cOLD41x8Eqvo3Nng==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1800,9 +1806,9 @@
           }
         },
         "globals": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-          "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
           "dev": true,
           "requires": {
             "type-fest": "^0.8.1"
@@ -1843,18 +1849,18 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.7.0.tgz",
-      "integrity": "sha512-FamQVKM3jjUVwhG4hEMnbtsq7xOIDm+SY5iBPfR8gKsJoAB2IQnNF+bk1+8Fy44Nq7PPJaLvkRxILYdJWoguKQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
+      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz",
-      "integrity": "sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
@@ -1886,13 +1892,13 @@
       "dev": true
     },
     "espree": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.0",
-        "acorn-jsx": "^5.1.0",
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
@@ -1903,9 +1909,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
@@ -2163,9 +2169,9 @@
       }
     },
     "figures": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-      "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -3119,39 +3125,80 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
-        "chalk": "^2.4.2",
+        "chalk": "^3.0.0",
         "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
-        "strip-ansi": "^5.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-escapes": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-          "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
           "dev": true,
           "requires": {
-            "type-fest": "^0.8.1"
+            "type-fest": "^0.11.0"
           }
         },
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -3169,18 +3216,31 @@
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^5.0.0"
-              }
-            }
           }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
         }
       }
     },
@@ -4393,12 +4453,6 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
-    "lodash.unescape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-      "dev": true
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5133,9 +5187,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha1-aCPnxZAAF7S9Os9G/prEtNe9qeo=",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -5412,18 +5466,18 @@
       "dev": true
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
       "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
       }
     },
     "rxjs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -6224,9 +6278,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha1-yDD2V/k/HqhGgZ6SkJL1/lmD6Xc=",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-embedded-metrics",
-  "version": "1.1.1",
+  "version": "2.0.0-rc1",
   "description": "AWS Embedded Metrics Client Library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -35,18 +35,18 @@
     "@types/faker": "^4.1.5",
     "@types/jest": "^24.0.15",
     "@types/node": "^12.0.8",
-    "@typescript-eslint/eslint-plugin": "^2.10.0",
-    "@typescript-eslint/parser": "^2.10.0",
+    "@typescript-eslint/eslint-plugin": "^2.23.0",
+    "@typescript-eslint/parser": "^2.23.0",
     "aws-sdk": "^2.551.0",
-    "eslint": "^6.7.2",
-    "eslint-config-prettier": "^6.7.0",
-    "eslint-plugin-prettier": "^3.1.1",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-prettier": "^3.1.2",
     "faker": "^4.1.0",
     "jest": "^24.8.0",
     "npm-pack-zip": "^1.2.7",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.5.2"
+    "typescript": "^3.8.0"
   },
   "files": [
     "lib/**/*"

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -17,4 +17,6 @@ export enum Constants {
   MAX_DIMENSIONS = 9,
   DEFAULT_NAMESPACE = 'aws-embedded-metrics',
   MAX_METRICS_PER_EVENT = 100,
+  DEFAULT_AGENT_HOST = '0.0.0.0',
+  DEFAULT_AGENT_PORT = 25888,
 }

--- a/src/environment/ECSEnvironment.ts
+++ b/src/environment/ECSEnvironment.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import config from '../config/Configuration';
+import { MetricsContext } from '../logger/MetricsContext';
+import { AgentSink } from '../sinks/AgentSink';
+import { ISink } from '../sinks/Sink';
+import { IEnvironment } from './IEnvironment';
+import { fetch } from '../utils/Fetch';
+import { LOG } from '../utils/Logger';
+import * as os from 'os';
+import { Constants } from '../Constants';
+
+interface IECSMetadataResponse {
+  Name: string;
+  DockerId: string;
+  DockerName: string;
+  Image: string;
+  FormattedImageName: string;
+  ImageID: string;
+  Ports: string;
+  Labels: IECSMetadataLabels;
+  CreatedAt: string;
+  StartedAt: string;
+  Networks: IECSMetadataNetworks[];
+}
+
+interface IECSMetadataLabels {
+  'com.amazonaws.ecs.cluster': string;
+  'com.amazonaws.ecs.container-name': string;
+  'com.amazonaws.ecs.task-arn': string;
+  'com.amazonaws.ecs.task-definition-family': string;
+  'com.amazonaws.ecs.task-definition-version': string;
+}
+
+interface IECSMetadataNetworks {
+  NetworkMode: string;
+  IPv4Addresses: string[];
+}
+
+// formats image names into something more readable for a metric name
+// e.g. <account-id>.dkr.ecr.<region>.amazonaws.com/<image-name>:latest -> <image-name>:latest
+const formatImageName = (imageName: string): string => {
+  if (imageName) {
+    const splitImageName = imageName.split('/');
+    return splitImageName[splitImageName.length - 1];
+  }
+  return imageName;
+};
+
+export class ECSEnvironment implements IEnvironment {
+  private sink: ISink | undefined;
+  private metadata: IECSMetadataResponse | undefined;
+  private fluentBitEndpoint: string | undefined;
+
+  public async probe(): Promise<boolean> {
+    if (!process.env.ECS_CONTAINER_METADATA_URI) {
+      return Promise.resolve(false);
+    }
+
+    if (process.env.FLUENT_HOST && !config.agentEndpoint) {
+      this.fluentBitEndpoint = `tcp://${process.env.FLUENT_HOST}:${Constants.DEFAULT_AGENT_PORT}`;
+      config.agentEndpoint = this.fluentBitEndpoint;
+      LOG(`Using FluentBit configuration. Endpoint: ${this.fluentBitEndpoint}`);
+    }
+
+    try {
+      this.metadata = await fetch<IECSMetadataResponse>(process.env.ECS_CONTAINER_METADATA_URI);
+      if (this.metadata) {
+        this.metadata.FormattedImageName = formatImageName(this.metadata.Image);
+        LOG(`Successfully collected ECS Container metadata.`);
+      }
+    } catch (e) {
+      LOG('Failed to collect ECS Container Metadata.');
+      LOG(e);
+    }
+
+    // return true regardless of whether or not metadata collection
+    // succeeded. we know that this is supposed to be an ECS environment
+    // just from the environment variable
+    return true;
+  }
+
+  public getName(): string {
+    if (config.serviceName) {
+      return config.serviceName;
+    }
+
+    return this.metadata?.FormattedImageName ? this.metadata.FormattedImageName : 'Unknown';
+  }
+
+  public getType(): string {
+    return 'AWS::ECS::Container';
+  }
+
+  public getLogGroupName(): string {
+    // FireLens / fluent-bit does not need the log group to be included
+    // since configuration of the LogGroup is handled by the
+    // fluent bit config file
+    if (this.fluentBitEndpoint) {
+      return '';
+    }
+
+    return config.logGroupName || this.getName();
+  }
+
+  public configureContext(context: MetricsContext): void {
+    this.addProperty(context, 'containerId', os.hostname());
+    this.addProperty(context, 'createdAt', this.metadata?.CreatedAt);
+    this.addProperty(context, 'startedAt', this.metadata?.StartedAt);
+    this.addProperty(context, 'image', this.metadata?.Image);
+    this.addProperty(context, 'cluster', this.metadata?.Labels['com.amazonaws.ecs.cluster']);
+    this.addProperty(context, 'taskArn', this.metadata?.Labels['com.amazonaws.ecs.task-arn']);
+
+    // we override the standard default dimensions here because in the
+    // FireLens / fluent-bit case, we don't need the LogGroup
+    if (this.fluentBitEndpoint) {
+      context.setDefaultDimensions({
+        ServiceName: config.serviceName || this.getName(),
+        ServiceType: config.serviceType || this.getType(),
+      });
+    }
+  }
+
+  public getSink(): ISink {
+    if (!this.sink) {
+      const logGroupName = this.fluentBitEndpoint ? '' : this.getLogGroupName();
+      this.sink = new AgentSink(logGroupName);
+    }
+    return this.sink;
+  }
+
+  private addProperty(context: MetricsContext, key: string, value: string | undefined): void {
+    if (value) {
+      context.setProperty(key, value);
+    }
+  }
+}

--- a/src/environment/Environments.ts
+++ b/src/environment/Environments.ts
@@ -3,6 +3,7 @@ enum Environments {
   Lambda = 'Lambda',
   Agent = 'Agent',
   EC2 = 'EC2',
+  ECS = 'ECS',
   Unknown = '',
 }
 

--- a/src/environment/__tests__/ECSEnvironment.test.ts
+++ b/src/environment/__tests__/ECSEnvironment.test.ts
@@ -1,0 +1,315 @@
+import * as faker from 'faker';
+import config from '../../config/Configuration';
+import { ECSEnvironment } from '../ECSEnvironment';
+import { MetricsContext } from '../../logger/MetricsContext';
+import { fetch } from '../../utils/Fetch';
+
+import * as os from 'os';
+import { Constants } from '../../Constants';
+jest.mock('../../utils/Fetch', () => ({
+  fetch: jest.fn(),
+}));
+
+beforeEach(() => {
+  config.agentEndpoint = undefined;
+  config.serviceName = undefined;
+  config.logGroupName = undefined;
+  process.env = {
+    ECS_CONTAINER_METADATA_URI: faker.internet.ip(),
+  };
+});
+
+describe('probe', () => {
+  test('returns false if ECS_CONTAINER_METADATA_URI not set', async () => {
+    // arrange
+    process.env.ECS_CONTAINER_METADATA_URI = '';
+    const env = new ECSEnvironment();
+
+    // act
+    const result = await env.probe();
+
+    // assert
+    expect(result).toBe(false);
+  });
+
+  test('returns true if ECS_CONTAINER_METADATA_URI set', async () => {
+    // arrange -- env var is set in beforeEach
+    const env = new ECSEnvironment();
+
+    // act
+    const result = await env.probe();
+
+    // assert
+    expect(result).toBe(true);
+  });
+
+  test('configures endpoint to use fluent bit if set', async () => {
+    // arrange
+    process.env.FLUENT_HOST = faker.internet.ip();
+    const expectedEndpoint = `tcp://${process.env.FLUENT_HOST}:${Constants.DEFAULT_AGENT_PORT}`;
+
+    const env = new ECSEnvironment();
+
+    // act
+    await env.probe();
+
+    // assert
+    expect(config.agentEndpoint).toBe(expectedEndpoint);
+  });
+
+  test('does not configure fluent bit endpoint if override specified', async () => {
+    // arrange
+    const configuredOverride = faker.internet.ip();
+    config.agentEndpoint = configuredOverride;
+    process.env.FLUENT_HOST = faker.internet.ip();
+
+    const env = new ECSEnvironment();
+
+    // act
+    await env.probe();
+
+    // assert
+    expect(config.agentEndpoint).toBe(configuredOverride);
+  });
+});
+
+describe('configureContext()', () => {
+  test('uses ECS metadata', async () => {
+    // arrange
+    const expected = getRandomECSMetadata();
+
+    // @ts-ignore
+    fetch.mockImplementation(() => expected);
+    const env = new ECSEnvironment();
+    await env.probe();
+
+    // act
+    const ctx = MetricsContext.empty();
+    env.configureContext(ctx);
+
+    // assert
+    expect(ctx.properties.containerId).toBe(os.hostname());
+    expect(ctx.properties.createdAt).toBe(expected.CreatedAt);
+    expect(ctx.properties.startedAt).toBe(expected.StartedAt);
+    expect(ctx.properties.image).toBe(expected.Image);
+    expect(ctx.properties.cluster).toBe(expected.Labels['com.amazonaws.ecs.cluster']);
+    expect(ctx.properties.taskArn).toBe(expected.Labels['com.amazonaws.ecs.task-arn']);
+  });
+
+  test('does not set default dimensions if fluent bit is not set', async () => {
+    // arrange
+    const expected = getRandomECSMetadata();
+
+    // @ts-ignore
+    fetch.mockImplementation(() => expected);
+    const env = new ECSEnvironment();
+    await env.probe();
+
+    // act
+    const ctx = MetricsContext.empty();
+    env.configureContext(ctx);
+
+    // assert
+    expect(ctx.getDimensions().length).toBe(0);
+  });
+
+  test('sets default dimensions without LogGroup if fluent bit is set', async () => {
+    // arrange
+    process.env.FLUENT_HOST = faker.internet.ip();
+    const expected = getRandomECSMetadata();
+
+    // @ts-ignore
+    fetch.mockImplementation(() => expected);
+    const env = new ECSEnvironment();
+    await env.probe();
+
+    // act
+    const ctx = MetricsContext.empty();
+    env.configureContext(ctx);
+
+    // assert
+    expect(ctx.getDimensions().length).toBe(1);
+    const dimensionSet = ctx.getDimensions()[0];
+    expect(Object.keys(dimensionSet).length).toBe(2);
+    expect(dimensionSet['ServiceName']).toBe(expected.Image);
+    expect(dimensionSet['ServiceType']).toBe('AWS::ECS::Container');
+    expect(dimensionSet['LogGroup']).toBe(undefined);
+  });
+});
+
+describe('getLogGroupName()', () => {
+  test('is empty if FluentBit configured', async () => {
+    // arrange
+    process.env.FLUENT_HOST = faker.internet.ip();
+
+    const env = new ECSEnvironment();
+    await env.probe();
+
+    // act
+    const result = env.getLogGroupName();
+
+    // assert
+    expect(result).toBe('');
+  });
+
+  test('getLogGroupName() return override if configured', async () => {
+    // arrange
+    config.logGroupName = faker.random.alphaNumeric(10);
+
+    const env = new ECSEnvironment();
+    await env.probe();
+
+    // act
+    const result = env.getLogGroupName();
+
+    // assert
+    expect(result).toBe(config.logGroupName);
+  });
+
+  test('getLogGroupName() returns service name if not configured', async () => {
+    // arrange
+    config.serviceName = faker.random.alphaNumeric(10);
+
+    const env = new ECSEnvironment();
+    await env.probe();
+
+    // act
+    const result = env.getLogGroupName();
+
+    // assert
+    expect(result).toBe(config.serviceName);
+  });
+});
+
+describe('getName()', () => {
+  test('returns service name if configured', async () => {
+    // arrange
+    config.serviceName = faker.random.alphaNumeric(10);
+
+    const env = new ECSEnvironment();
+    await env.probe();
+
+    // act
+    const result = env.getName();
+
+    // assert
+    expect(result).toBe(config.serviceName);
+  });
+
+  test('returns formatted image name if available', async () => {
+    // arrange
+    const formattedImageName = `${faker.lorem.word()}:latest`;
+    const fullImageName = `${faker.random.number({
+      min: 0,
+      max: 999999999999,
+    })}.dkr.ecr.<region>.amazonaws.com/${formattedImageName}`;
+    const metadata = {
+      Image: fullImageName,
+      Labels: {},
+    };
+
+    // @ts-ignore
+    fetch.mockImplementation(() => metadata);
+    const env = new ECSEnvironment();
+    await env.probe();
+
+    // act
+    const result = env.getName();
+
+    // assert
+    expect(result).toBe(formattedImageName);
+  });
+
+  test('returns Unknown if image name is undefined', async () => {
+    // arrange
+    const expectedName = `Unknown`;
+    const metadata = {
+      Image: undefined,
+      Labels: {},
+    };
+
+    // @ts-ignore
+    fetch.mockImplementation(() => metadata);
+    const env = new ECSEnvironment();
+    await env.probe();
+
+    // act
+    const result = env.getName();
+
+    // assert
+    expect(result).toBe(expectedName);
+  });
+
+  test('returns Unknown if image not available', async () => {
+    // arrange
+    // @ts-ignore
+    fetch.mockImplementation(() => {
+      return {};
+    });
+    const env = new ECSEnvironment();
+    await env.probe();
+
+    // act
+    const result = env.getName();
+
+    // assert
+    expect(result).toBe('Unknown');
+  });
+});
+
+describe('getType()', () => {
+  test('returns AWS::ECS::Container', () => {
+    // arrange
+    const env = new ECSEnvironment();
+
+    // act
+    const result = env.getType();
+
+    // assert
+    expect(result).toBe('AWS::ECS::Container');
+  });
+});
+
+describe('getSink()', () => {
+  test('returns AgentSink without LogGroup if FluentBit configured', async () => {
+    // arrange
+    process.env.FLUENT_HOST = faker.internet.ip();
+
+    const env = new ECSEnvironment();
+    await env.probe();
+
+    // act
+    const result: any = env.getSink();
+
+    // assert
+    expect(result.name).toBe('AgentSink');
+    expect(result.logGroupName).toBe('');
+  });
+
+  test('returns AgentSink with LogGroup if FluentBit not configured', async () => {
+    // arrange
+    config.logGroupName = faker.lorem.word();
+
+    const env = new ECSEnvironment();
+    await env.probe();
+
+    // act
+    const result: any = env.getSink();
+
+    // assert
+    expect(result.name).toBe('AgentSink');
+    expect(result.logGroupName).toBe(config.logGroupName);
+  });
+});
+
+const getRandomECSMetadata = (): any => {
+  return {
+    CreatedAt: faker.date.past(),
+    StartedAt: faker.date.past(),
+    Image: faker.lorem.word(),
+    Labels: {
+      'com.amazonaws.ecs.cluster': faker.random.alphaNumeric(),
+      'com.amazonaws.ecs.task-arn': faker.random.alphaNumeric(),
+    },
+  };
+};

--- a/src/environment/__tests__/EnvironmentDetector.test.ts
+++ b/src/environment/__tests__/EnvironmentDetector.test.ts
@@ -1,15 +1,22 @@
-import * as faker from 'faker';
 import { cleanResolveEnvironment } from '../EnvironmentDetector';
 import config from '../../config/Configuration';
 import Environments from '../Environments';
+import { DefaultEnvironment } from '../DefaultEnvironment';
+import { ECSEnvironment } from '../ECSEnvironment';
+import { EC2Environment } from '../EC2Environment';
+import { LambdaEnvironment } from '../LambdaEnvironment';
 
-beforeEach(() => {
-  process.env = {};
-});
+const envs = [LambdaEnvironment, ECSEnvironment, EC2Environment, DefaultEnvironment];
+const setEnvironment = (env: any) => {
+  envs.forEach(e => {
+    const probeResult = env === e;
+    e.prototype.probe = jest.fn(() => Promise.resolve(probeResult));
+  });
+};
 
 test('resolveEnvironment() returns LambdaEnvironment if AWS_LAMBDA_FUNCTION_NAME specified', async () => {
   // arrange
-  process.env.AWS_LAMBDA_FUNCTION_NAME = faker.random.word();
+  setEnvironment(LambdaEnvironment);
 
   // act
   const result = await cleanResolveEnvironment();
@@ -18,18 +25,32 @@ test('resolveEnvironment() returns LambdaEnvironment if AWS_LAMBDA_FUNCTION_NAME
   expect(result.constructor.name).toBe('LambdaEnvironment');
 });
 
+test('resolveEnvironment() returns ECSEnvironment if probe returns true', async () => {
+  // arrange
+  setEnvironment(ECSEnvironment);
+
+  // act
+  const result = await cleanResolveEnvironment();
+
+  // assert
+  expect(result.constructor.name).toBe('ECSEnvironment');
+});
+
 test('resolveEnvironment() returns DefaultEnvironment if nothing else was detected', async () => {
   // arrange
+  setEnvironment(undefined);
+
   // act
   const result = await cleanResolveEnvironment();
 
   // assert
   expect(result.constructor.name).toBe('DefaultEnvironment');
-}, 10000);
+});
 
 test('resolveEnvironment() honors configured override', async () => {
   // arrange
   config.environmentOverride = Environments.Local;
+  setEnvironment(ECSEnvironment);
 
   // act
   const result = await cleanResolveEnvironment();
@@ -42,7 +63,7 @@ test('resolveEnvironment() ignores invalid override and falls back to discovery'
   // arrange
   // @ts-ignore
   config.environmentOverride = 'Invalid';
-  process.env.AWS_LAMBDA_FUNCTION_NAME = faker.random.word();
+  setEnvironment(LambdaEnvironment);
 
   // act
   const result = await cleanResolveEnvironment();


### PR DESCRIPTION
- add ECSEnvironment
- bump TypeScript to 3.8
- bump lint tooling and fix-lint
- add ECSEnvironment tests
- use mocks in the environment detector tests
- update docs
- npm audit fix

Closes #17 
Closes #27 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
