### PR TITLE
Fix memory leak in TCP client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-embedded-metrics",
-  "version": "1.1.0",
+  "version": "1.1.1-alpha3",
   "description": "AWS Embedded Metrics Client Library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -12,7 +12,7 @@
     "node": ">=10.0.0"
   },
   "scripts": {
-    "test": "jest --config jestconfig.json",
+    "test": "jest --runInBand --detectOpenHandles --config jestconfig.json",
     "integ": "./bin/run-integ-tests.sh",
     "exec-integ": "jest --config jestconfig.integ.json",
     "watch": "npm run test -- --watch",

--- a/src/sinks/__tests__/AgentSink.test.ts
+++ b/src/sinks/__tests__/AgentSink.test.ts
@@ -39,14 +39,14 @@ test('can parse udp endpoints', () => {
 
 test('handles tcp connection error', async () => {
   // arrange
-  const noProcessPort = faker.random.number({ min: 1000, max: 9999 });
+  const noProcessPort = 6553;
   Configuration.agentEndpoint = `tcp://127.0.0.1:${noProcessPort}`;
   const context = MetricsContext.empty();
   const logGroupName = faker.random.word();
   const sink = new AgentSink(logGroupName);
 
   // assert
-  return expect(sink.accept(context)).rejects.toThrowError(/ECONNREFUSED/);
+  await expect(sink.accept(context)).rejects.toThrowError(/ECONNREFUSED/);
 });
 
 test('LogGroup is stored in metadata', async () => {
@@ -98,7 +98,7 @@ test('more than max number of metrics will send multiple messages', async () => 
   }
 
   let sentMessages = 0;
-  TcpClient.prototype.sendMessage = (message: Buffer): Promise<void> => {
+  TcpClient.prototype.sendMessage = (): Promise<void> => {
     sentMessages++;
     return Promise.resolve();
   };

--- a/src/sinks/__tests__/TcpClient.test.ts
+++ b/src/sinks/__tests__/TcpClient.test.ts
@@ -1,15 +1,119 @@
 import * as faker from 'faker';
 import { TcpClient } from '../connections/TcpClient';
+import sleep from '../../../test/utils/Sleep';
+import net = require('net');
 
 test('handles tcp client errors', async () => {
   // arrange
-  const noProcessPort = faker.random.number({ min: 1000, max: 9999 });
   const client = new TcpClient({
     host: '0.0.0.0',
-    port: noProcessPort,
+    port: 65535,
     protocol: 'tcp',
   });
 
   // assert
   return expect(client.sendMessage(Buffer.from([]))).rejects.toThrowError(/ECONNREFUSED/);
+});
+
+test('handles server disconnect', async () => {
+  // arrange
+  const port = 9999;
+  const successSends = faker.random.number({ min: 1, max: 100 });
+  const failedSends = faker.random.number({ min: 1, max: 100 });
+  const successSendsReconnect = faker.random.number({ min: 1, max: 100 });
+
+  let receivedMessages = 0;
+  const server = net.createServer(socket => socket.on('data', () => receivedMessages++)).listen(port, '0.0.0.0');
+
+  const client = new TcpClient({ host: '0.0.0.0', port: port, protocol: 'tcp' });
+  const killServer = async () => {
+    await new Promise(resolve => server.close(resolve));
+    server.unref();
+  };
+
+  let failedCount = 0;
+  const sendMessages = async (count: number) => {
+    for (let index = 0; index < count; index++) {
+      try {
+        await client.sendMessage(Buffer.from('test\n'));
+        // allow kernel + server time to get request
+        await sleep(20);
+      } catch (_) {
+        failedCount++;
+      }
+    }
+  };
+
+  // act
+  await sendMessages(successSends);
+  await killServer();
+  await sendMessages(failedSends);
+  server.listen(port, '0.0.0.0');
+  await sendMessages(successSendsReconnect);
+
+  // assert
+  expect(failedCount).toBe(failedSends);
+  expect(receivedMessages).toBe(successSends + successSendsReconnect);
+
+  // cleanup
+  // @ts-ignore
+  client.disconnect('cleanup');
+  await killServer();
+}, 10000);
+
+test('does not leak event listeners on failed sends', async () => {
+  // arrange
+  const runCount = 100;
+  const client = new TcpClient({
+    host: '0.0.0.0',
+    port: 65535,
+    protocol: 'tcp',
+  });
+
+  // act
+  let failedCount = 0;
+  for (let index = 0; index < runCount; index++) {
+    try {
+      await client.sendMessage(Buffer.from([]));
+    } catch (_) {
+      failedCount++;
+    }
+  }
+
+  // assert
+  expect(failedCount).toBe(runCount);
+
+  // @ts-ignore
+  const socket = client.socket;
+
+  expect(socket.listeners('error').length).toBe(0);
+  expect(socket.listeners('connect').length).toBe(1);
+  expect(socket.listeners('timeout').length).toBe(0);
+});
+
+test('does not leak event listeners on successful sends', async () => {
+  // arrange
+  const port = 9999;
+  const server = net.createServer(socket => socket.pipe(socket)).listen(port, '0.0.0.0');
+  const client = new TcpClient({
+    host: '0.0.0.0',
+    port: port,
+    protocol: 'tcp',
+  });
+
+  // act
+  for (let index = 0; index < 100; index++) {
+    await client.sendMessage(Buffer.from([]));
+  }
+
+  server.close();
+  server.unref();
+
+  // assert
+  // @ts-ignore
+  const socket = client.socket;
+
+  expect(socket.listeners('error').length).toBe(0);
+  expect(socket.listeners('connect').length).toBe(0);
+  expect(socket.listeners('timeout').length).toBe(1);
 });


### PR DESCRIPTION
Closes #32 

The `error` listener was added to catch `ECONNREFUSED` prior to actually writing to the socket. If the connection is not open then the `write` callback will not be executed. The actual bug here is that `sendMessage` is supposed to be checking if the connection can be written to. We assume the connection has been established because `this.socket.writable` is `true`, but the socket is not actually open yet (e.g. may be writeable but readyState is `opening`).

![image](https://user-images.githubusercontent.com/13851721/77240172-22bd6b80-6ba0-11ea-96f7-496e1088a76f.png)


https://github.com/awslabs/aws-embedded-metrics-node/blob/8bc900218ab18d2fca59bf29211c77d366f83e66/src/sinks/connections/TcpClient.ts#L44-L45

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
