### PR TITLE
Added ECS as a supported Env Override on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Valid values include:
 - Lambda: decorates logs with Lambda metadata and sends over stdout
 - Agent: no decoration and sends over TCP
 - EC2: decorates logs with EC2 metadata and sends over TCP
+- ECS: decorates logs with ECS metadata and enables support for Firelens
 
 Example:
 


### PR DESCRIPTION
*Pull Request/Issue #, if available:* [28](https://github.com/awslabs/aws-embedded-metrics-node/pull/28)

*Description of changes:*

I can see that support for ECS and firelens was added on the previously mentioned PR.

I can also see that the [code](https://github.com/awslabs/aws-embedded-metrics-node/blob/730bbaeb341ee3952a404c04fc1de59a6ec65cf5/src/environment/EnvironmentDetector.ts#L50-L51) for Environment Overrides supports the `ECS` value, yet we do not mention it in the documentation as a supported value:

```
const getEnvironmentFromOverride = (): IEnvironment | undefined => {
  // short-circuit environment detection and use override
  switch (config.environmentOverride) {
    case Environments.Agent:
      return defaultEnvironment;
    case Environments.EC2:
      return ec2Environment;
    case Environments.Lambda:
      return lambdaEnvironment;
    case Environments.ECS:
      return ecsEnvironment;
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
