### PR TITLE
Fix 'Socket is closed' error on node v14

### DIFF
--- a/src/sinks/connections/TcpClient.ts
+++ b/src/sinks/connections/TcpClient.ts
@@ -29,7 +29,7 @@ export class TcpClient implements ISocketClient {
 
   constructor(endpoint: IEndpoint) {
     this.endpoint = endpoint;
-    this.socket = new net.Socket({ allowHalfOpen: true })
+    this.socket = new net.Socket({ allowHalfOpen: true, writable: false })
       .setEncoding('utf8')
       .setKeepAlive(true)
       .setTimeout(5000) // idle timeout


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/aws-embedded-metrics-node/issues/58

Before this change I get this when testing with node v14:

```
Resolving environment
Discovering environment
Testing: LambdaEnvironment
Testing: EC2Environment
Socket timeout while connecting to 'http://169.254.169.254/latest/dynamic/instance-identity/document'
Unknown ServiceName.
Unknown ServiceName.
Unknown ServiceType.
Received default dimensions {
  LogGroup: 'Unknown-metrics',
  ServiceName: 'Unknown',
  ServiceType: 'Unknown'
}
Unknown ServiceName.
Getting socket client for connection. { host: '0.0.0.0', port: 25888, protocol: 'tcp:' }
Using socket client TcpClient
TcpClient data was not flushed to kernel buffer and was queued in memory.
Failed to write Error [ERR_SOCKET_CLOSED]: Socket is closed
    at Socket._writeGeneric (net.js:775:8)
    at Socket._write (net.js:797:8)
    at writeOrBuffer (_stream_writable.js:352:12)
    at Socket.Writable.write (_stream_writable.js:303:10)
    at /Users/danespringmeyer/projects/api-gl6/node_modules/aws-embedded-metrics/lib/sinks/connections/TcpClient.js:57:56
    at new Promise (<anonymous>)
    at TcpClient.<anonymous> (/Users/danespringmeyer/projects/api-gl6/node_modules/aws-embedded-metrics/lib/sinks/connections/TcpClient.js:52:19)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/danespringmeyer/projects/api-gl6/node_modules/aws-embedded-metrics/lib/sinks/connections/TcpClient.js:18:58)
    at processTicksAndRejections (internal/process/task_queues.js:93:5) {
  code: 'ERR_SOCKET_CLOSED'
```

After this fix I see:

```
Resolving environment
Discovering environment
Testing: LambdaEnvironment
Testing: EC2Environment
Socket timeout while connecting to 'http://169.254.169.254/latest/dynamic/instance-identity/document'
Unknown ServiceName.
Unknown ServiceName.
Unknown ServiceType.
Received default dimensions {
  LogGroup: 'Unknown-metrics',
  ServiceName: 'Unknown',
  ServiceType: 'Unknown'
}
Unknown ServiceName.
Getting socket client for connection. { host: '0.0.0.0', port: 25888, protocol: 'tcp:' }
opening connection with socket in state:  readOnly
Using socket client TcpClient
TcpClient connected. { host: '0.0.0.0', port: 25888, protocol: 'tcp:' }
TcpClient connected. { host: '0.0.0.0', port: 25888, protocol: 'tcp:' }
Write succeeded
```

*Description of changes:*

- Adapts to https://github.com/nodejs/node/commit/eeccd52b4ef2db3219fc76737bb00c1da669aea2#diff-218c57e035f64b18af4db037c96f13014aeb40a1f783d4f52919e2075621da0c from @ronag 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
