### PR TITLE
Deduplicate RELEASE_NOTES and Releases list

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,18 +1,3 @@
 # Release Notes
 
-## v1.1.1
-
-- Fixed TCP Client Memory Leak (#32 via #34). Thanks @davidtheclark!
-
-## v1.1.0
-
-- Preserve the logger context across flushes
-- Merge duplicate dimension sets
-- Add environment override and LocalEnvironment
-- Make LogGroup optional for DefaultEnvironment
-- Set Max Dimensions = 9
-- Support more than 100 metrics transparently
-
-## v1.0.0
-
-Initial release
+See the repository's [Releases list](https://github.com/awslabs/aws-embedded-metrics-node/releases).


### PR DESCRIPTION
*Description of changes:*

I looked at `RELEASE_NOTES.md` for information about the latest releases and was confused by their absence. Then I found all the notes in the GitHub Releases page. This PR suggests using the Releases list as the sole source of release notes.

An alternative approach is to delete `RELEASE_NOTES.md`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
