### PR TITLE
Allow setting timestamp of metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ setNamespace("MyApplication");
 
 Sets the CloudWatch [timestamp](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#about_timestamp) that extracted metrics are associated with. If not set a default value of `new Date()` will be used.
 
-If set, timestamp will be preserved across calls to flush().
+If set for a given `MetricsLogger`, timestamp will be preserved across calls to flush().
 
 Requirements: 
  * Date or Unix epoch millis, up to two weeks in the past and up to two hours in the future, as enforced by [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#about_timestamp). 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,25 @@ Examples:
 setNamespace("MyApplication");
 ```
 
+- **setTimestamp**(Date | number timestamp)
+
+Sets the CloudWatch [timestamp](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#about_timestamp) that extracted metrics are associated with. If not set a default value of `new Date()` will be used.
+
+If set, timestamp will be preserved across calls to flush().
+
+Requirements: 
+ * Date or Unix epoch millis, up to two weeks in the past and up to two hours in the future, as enforced by [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#about_timestamp). 
+
+Examples:
+
+```py
+setTimestamp(new Date())
+setTimestamp(new Date().getTime())
+```
+
 - **flush**()
 
-Flushes the current MetricsContext to the configured sink and resets all properties, dimensions and metric values. The namespace and default dimensions will be preserved across flushes.
+Flushes the current MetricsContext to the configured sink and resets all properties, dimensions and metric values. The namespace and default dimensions will be preserved across flushes. Timestamp will be preserved if set explicitly via `setTimestamp()`.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Requirements:
 
 Examples:
 
-```py
+```js
 setNamespace("MyApplication");
 ```
 
@@ -202,7 +202,7 @@ Requirements:
 
 Examples:
 
-```py
+```js
 setTimestamp(new Date())
 setTimestamp(new Date().getTime())
 ```

--- a/src/logger/MetricsContext.ts
+++ b/src/logger/MetricsContext.ts
@@ -39,6 +39,7 @@ export class MetricsContext {
   private dimensions: Array<Record<string, string>>;
   private defaultDimensions: Record<string, string>;
   private shouldUseDefaultDimensions = true;
+  private timestamp: Date | number | undefined;
 
   /**
    * Constructor used to create child instances.
@@ -56,12 +57,24 @@ export class MetricsContext {
     properties?: IProperties,
     dimensions?: Array<Record<string, string>>,
     defaultDimensions?: Record<string, string>,
+    timestamp?: Date | number,
   ) {
     this.namespace = namespace || Configuration.namespace
     this.properties = properties || {};
     this.dimensions = dimensions || [];
-    this.meta.Timestamp = new Date().getTime();
+    this.timestamp = timestamp;
+    this.meta.Timestamp = MetricsContext.resolveMetaTimestamp(timestamp);
     this.defaultDimensions = defaultDimensions || {};
+  }
+
+  private static resolveMetaTimestamp(timestamp?: Date | number): number {
+    if (timestamp instanceof Date) {
+      return timestamp.getTime()
+    } else if (timestamp) {
+      return timestamp;
+    } else {
+      return new Date().getTime();
+    }
   }
 
   public setNamespace(value: string): void {
@@ -70,6 +83,11 @@ export class MetricsContext {
 
   public setProperty(key: string, value: unknown): void {
     this.properties[key] = value;
+  }
+
+  public setTimestamp(timestamp: Date | number) {
+    this.timestamp = timestamp;
+    this.meta.Timestamp = MetricsContext.resolveMetaTimestamp(timestamp);
   }
 
   /**
@@ -173,6 +191,7 @@ export class MetricsContext {
       Object.assign({}, this.properties),
       Object.assign([], this.dimensions),
       this.defaultDimensions,
+      this.timestamp
     );
   }
 }

--- a/src/logger/MetricsLogger.ts
+++ b/src/logger/MetricsLogger.ts
@@ -115,6 +115,21 @@ export class MetricsLogger {
   }
 
   /**
+   * Set the timestamp of metrics emitted in this context.
+   *
+   * If not set, the timestamp will default to new Date() at the point
+   * the context is constructed.
+   *
+   * If set, timestamp will preserved across calls to flush().
+   *
+   * @param timestamp
+   */
+  public setTimestamp(timestamp: Date | number): MetricsLogger {
+    this.context.setTimestamp(timestamp);
+    return this;
+  }
+
+  /**
    * Creates a new logger using the same contextual data as
    * the previous logger. This allows you to flush the instances
    * independently.


### PR DESCRIPTION
*Issue #, if available:* 61
https://github.com/awslabs/aws-embedded-metrics-node/issues/61

*Description of changes:*
Adds the MetricsLogger.setTimestamp() method.

One aspect I think core maintainers will have a much better sense of, if I set the timestamp should that be preserved across calls to `flush()`? I wasn't 100% sure what would be desired behaviour, so I took a guess and went for "yes, if set explicitly, preserve". For my own use case described in #61, I will be calling `setTimeout` in 100% of `MetricsContext` instances generated, so it would be irrelevant anyway.

Another guess I made was that if the timestamp is not set explicitly, the `MetricsContext` should reset the `meta.Timestamp` field to `new Date()`. I think this is less surprising behaviour for users who never call `setTimestamp`. Plus if I preserved the timestamp when not explicitly set, that would change the behaviour for all existing users, I thought it would only make sense to change behaviour for callers who are "opting in" by using `setTimeout`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
