### PR TITLE
Copy shouldUseDefaultDimensions to new MetricsContext

### DIFF
--- a/src/logger/MetricsContext.ts
+++ b/src/logger/MetricsContext.ts
@@ -56,12 +56,16 @@ export class MetricsContext {
     properties?: IProperties,
     dimensions?: Array<Record<string, string>>,
     defaultDimensions?: Record<string, string>,
+    shouldUseDefaultDimensions?: boolean,
   ) {
     this.namespace = namespace || Configuration.namespace
     this.properties = properties || {};
     this.dimensions = dimensions || [];
     this.meta.Timestamp = new Date().getTime();
     this.defaultDimensions = defaultDimensions || {};
+    if (shouldUseDefaultDimensions != undefined) {
+      this.shouldUseDefaultDimensions = shouldUseDefaultDimensions
+    }
   }
 
   public setNamespace(value: string): void {
@@ -173,6 +177,7 @@ export class MetricsContext {
       Object.assign({}, this.properties),
       Object.assign([], this.dimensions),
       this.defaultDimensions,
+      this.shouldUseDefaultDimensions
     );
   }
 }

--- a/src/logger/__tests__/MetricsContext.test.ts
+++ b/src/logger/__tests__/MetricsContext.test.ts
@@ -189,3 +189,17 @@ test('createCopyWithContext copies properties and dimensions', () => {
   expect(newContext).not.toBe(context);
   expect(newContext).toStrictEqual(context);
 });
+
+test('createCopyWithContext copies shouldUseDefaultDimensions', () => {
+  // arrange
+  const context = MetricsContext.empty();
+  context.setDimensions([]);
+  context.setDefaultDimensions({ Key: 'Value' });
+
+  // act
+  const newContext = context.createCopyWithContext();
+
+  // assert
+  expect(newContext).not.toBe(context);
+  expect(newContext.getDimensions()).toEqual([])
+});


### PR DESCRIPTION
*Issue #71*

*Description of changes:*
Using shouldUseDefaultDimensions to populate new MetricsContext on copy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
