### PR TITLE
new Date().getTime() -> Date.now()

### DIFF
--- a/src/logger/MetricsContext.ts
+++ b/src/logger/MetricsContext.ts
@@ -77,7 +77,7 @@ export class MetricsContext {
     } else if (timestamp) {
       return timestamp;
     } else {
-      return new Date().getTime();
+      return Date.now();
     }
   }
 


### PR DESCRIPTION
The latter is preferred and more efficient.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
