### PR TITLE
Simplify error handling in MetricScope wrapper

### DIFF
--- a/src/logger/MetricScope.ts
+++ b/src/logger/MetricScope.ts
@@ -22,14 +22,11 @@ import { createMetricsLogger } from './MetricsLoggerFactory';
  */
 const metricScope = <T, U extends readonly unknown[]>(
   handler: (m: MetricsLogger) => (...args: U) => T | Promise<T>,
-): ((...args: U) => Promise<T | undefined>) => {
-  const wrappedHandler = async (...args: U): Promise<T | undefined> => {
+): ((...args: U) => Promise<T>) => {
+  const wrappedHandler = async (...args: U): Promise<T> => {
     const metrics = createMetricsLogger();
-    let exception;
     try {
       return await handler(metrics)(...args);
-    } catch (e) {
-      exception = e;
     } finally {
       try {
         await metrics.flush();
@@ -37,12 +34,6 @@ const metricScope = <T, U extends readonly unknown[]>(
         LOG('Failed to flush metrics', e);
       }
     }
-
-    if (exception) {
-      throw exception;
-    }
-
-    return;
   };
   return wrappedHandler;
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`metricScope` now lets the regular try-catch-finally semantics be
responsible for propagating any errors from the handler instead of
rethrowing them manually. This allows the wrapper's return type to
mirror the handler more accurately, eliminating the `| undefined`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
