### PR TITLE
fix high sev CVE-2020-7774 in build deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "npm-pack-zip": "^1.2.7",
         "prettier": "^1.19.1",
         "ts-jest": "^26.5.4",
-        "typescript": "^3.8.0"
+        "typescript": "^3.8.0",
+        "y18n": ">=4.0.1"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -6681,9 +6682,9 @@
       "dev": true
     },
     "node_modules/npm-pack-zip": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/npm-pack-zip/-/npm-pack-zip-1.2.7.tgz",
-      "integrity": "sha512-hnbp8OF0/Np+OpkIoEIKqo7EFcKMV/eMMzrRdB37bdqdbH5PDHVKv/9b8EhDvjrKDxDK/N9rmRoJFdB81JNoCg==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/npm-pack-zip/-/npm-pack-zip-1.2.9.tgz",
+      "integrity": "sha512-IB5bGt8kSzIn4UsuYXT91+fLa5B59Xj7HDB+eRQO9tlX5f+Q5yK3s2eE6XA4Rm73tuD7BLFiXUiZilU763OBTg==",
       "dev": true,
       "dependencies": {
         "archiver-promise": "^1.0.0",
@@ -6771,9 +6772,9 @@
       "dev": true
     },
     "node_modules/npm-pack-zip/node_modules/y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
       "dev": true
     },
     "node_modules/npm-pack-zip/node_modules/yargs": {
@@ -14968,9 +14969,9 @@
       "dev": true
     },
     "npm-pack-zip": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/npm-pack-zip/-/npm-pack-zip-1.2.7.tgz",
-      "integrity": "sha512-hnbp8OF0/Np+OpkIoEIKqo7EFcKMV/eMMzrRdB37bdqdbH5PDHVKv/9b8EhDvjrKDxDK/N9rmRoJFdB81JNoCg==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/npm-pack-zip/-/npm-pack-zip-1.2.9.tgz",
+      "integrity": "sha512-IB5bGt8kSzIn4UsuYXT91+fLa5B59Xj7HDB+eRQO9tlX5f+Q5yK3s2eE6XA4Rm73tuD7BLFiXUiZilU763OBTg==",
       "dev": true,
       "requires": {
         "archiver-promise": "^1.0.0",
@@ -15037,9 +15038,9 @@
           "dev": true
         },
         "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+          "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
           "dev": true
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "npm-pack-zip": "^1.2.7",
     "prettier": "^1.19.1",
     "ts-jest": "^26.5.4",
-    "typescript": "^3.8.0"
+    "typescript": "^3.8.0",
+    "y18n": ">=4.0.1"
   },
   "files": [
     "lib/**/*"


### PR DESCRIPTION
https://github.com/advisories/GHSA-c4w7-xm78-47vh

The npm package y18n before versions 3.2.2, 4.0.1, and 5.0.5 is vulnerable to Prototype Pollution.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
