### PR TITLE
Added warnings to MetricsLogger->setDimensions, putDimensions and set…

### DIFF
--- a/src/logger/__tests__/MetricsLogger.test.ts
+++ b/src/logger/__tests__/MetricsLogger.test.ts
@@ -186,6 +186,46 @@ describe('successful', () => {
     expect(actualValue).toBe(expectedValue);
   });
 
+  test('logs a warning when setting a property with the same name as an existing dimension', async () => {
+    // arrange
+    const consoleWarnSpy = jest.spyOn(global.console, 'warn');
+    const property1Name = '1';
+    const property1Value = '1';
+    const dimension1: Record<string, string> = {'1': '1'};
+
+    // act
+    logger.setDimensions(dimension1);
+    logger.setProperty(property1Name, property1Value);
+
+    // assert
+    expect(console.warn).toHaveBeenCalledTimes(1);
+
+    // clear
+    consoleWarnSpy.mockClear();
+  });
+
+  test('logs a warning when creating a dimension with the same name as an existing property that does not belong to an existing dimension', async () => {
+    // arrange
+    const consoleWarnSpy = jest.spyOn(global.console, 'warn');
+    const property1Name = '1';
+    const property1Value = '1';
+    const property2Name = '2';
+    const property2Value = '2';
+    const dimension1: Record<string, string> = {'1': '1'};
+    const dimension2: Record<string, string> = {'2': '2'};
+
+    // act
+    logger.setProperty(property1Name, property1Value);
+    logger.setDimensions(dimension1);
+    logger.setProperty(property2Name, property2Value);
+    logger.putDimensions(dimension2);
+    // assert
+    expect(console.warn).toHaveBeenCalledTimes(2);
+
+    // clear
+    consoleWarnSpy.mockClear();
+  });
+
   test('can set namespace', async () => {
     // arrange
     const expectedValue = faker.random.word();


### PR DESCRIPTION
The values of dimensions are stored in the root node, as described in the [documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html#CloudWatch_Embedded_Metric_Format_Specification_structure_dimensionset). It is possible to overwrite the value of the given dimension if you create a property with the same name as the previously defined dimension name. This can lead to unexpected behaviour, especially when the users do not know the full specification of the `_aws` object. Furthermore, it is possible to overwrite the value of a dimension with a number. This will cause the metrics to be created with no dimensions, even though they are technically defined in the `_aws.CloudWatchMetrics.Dimensions` array. The reason is that the CloudWatch backend expects strings when parsing the values of dimensions. The proposed patch creates validation functions that call `console.warn` with appropriate messages when the user:
1. Modifies the value of an existing dimension with the `MetricsLogger.setProperty` function
2. Creates a dimension with a value that is not a string
3. Creates a dimension with a name that already exists as a property in the root node and does not belong to any existing dimension (i.e. has been created with the `MetricsLogger.setProperty` function)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.