### PR TITLE
Explicitly type convert metric values to Number().

### DIFF
--- a/src/logger/MetricsContext.ts
+++ b/src/logger/MetricsContext.ts
@@ -180,9 +180,9 @@ export class MetricsContext {
   public putMetric(key: string, value: number, unit?: Unit | string): void {
     const currentMetric = this.metrics.get(key);
     if (currentMetric) {
-      currentMetric.addValue(value);
+      currentMetric.addValue(Number(value));
     } else {
-      this.metrics.set(key, new MetricValues(value, unit));
+      this.metrics.set(key, new MetricValues(Number(value), unit));
     }
   }
 

--- a/src/logger/__tests__/MetricsLogger.test.ts
+++ b/src/logger/__tests__/MetricsLogger.test.ts
@@ -83,6 +83,25 @@ describe('successful', () => {
     expect(actualMetric!.unit).toBe('None');
   });
 
+  test('put metric with string corerces to Numeric', async () => {
+    // arrange
+    const expectedKey = faker.random.word();
+    const expectedValues = [faker.random.number(), faker.random.number()];
+
+    // act
+    logger.putMetric(expectedKey, `${expectedValues[0]}` as any);
+    logger.putMetric(expectedKey, `${expectedValues[1]}` as any);
+    await logger.flush();
+
+    // assert
+    expect(sink.events).toHaveLength(1);
+    const actualMetric = sink.events[0].metrics.get(expectedKey);
+    expect(actualMetric).toBeTruthy();
+    expect(actualMetric!.values).toStrictEqual(expectedValues);
+    expect(actualMetric!.unit).toBe('None');
+  });
+
+
   test('can put metric with enum unit', async () => {
     // arrange
     const expectedKey = faker.random.word();


### PR DESCRIPTION
Fixes #106

This is a suggested / potential fix for the issue in #106 where it's possible to submit correct looking metrics which are then interpreted as `0` by AWS because the value ends up quoted in the generated JSON