### PR TITLE
Migrate from IMDSv1 to IMDSv2

### DIFF
--- a/src/environment/EC2Environment.ts
+++ b/src/environment/EC2Environment.ts
@@ -17,7 +17,7 @@ import config from '../config/Configuration';
 import { MetricsContext } from '../logger/MetricsContext';
 import { AgentSink } from '../sinks/AgentSink';
 import { ISink } from '../sinks/Sink';
-import { fetch, fetchString } from '../utils/Fetch';
+import { fetchJSON, fetchString } from '../utils/Fetch';
 import { LOG } from '../utils/Logger';
 import { IEnvironment } from './IEnvironment';
 import { RequestOptions } from 'http';
@@ -65,7 +65,7 @@ export class EC2Environment implements IEnvironment {
         method: "GET",
         headers: {[metadataRequestTokenHeaderKey]: this.token}
       }
-      this.metadata = await fetch<IEC2MetadataResponse>(metadataOptions);
+      this.metadata = await fetchJSON<IEC2MetadataResponse>(metadataOptions);
       return !!this.metadata;
     } catch (e) {
       LOG(e);

--- a/src/environment/EC2Environment.ts
+++ b/src/environment/EC2Environment.ts
@@ -22,6 +22,8 @@ import { LOG } from '../utils/Logger';
 import { IEnvironment } from './IEnvironment';
 import { RequestOptions } from 'http';
 
+// Documentation for configuring instance metadata can be found here:
+// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
 const host = '169.254.169.254';
 const tokenPath = '/latest/api/token';
 const tokenRequestHeaderKey = 'X-aws-ec2-metadata-token-ttl-seconds';

--- a/src/environment/EC2Environment.ts
+++ b/src/environment/EC2Environment.ts
@@ -17,7 +17,7 @@ import config from '../config/Configuration';
 import { MetricsContext } from '../logger/MetricsContext';
 import { AgentSink } from '../sinks/AgentSink';
 import { ISink } from '../sinks/Sink';
-import { fetchWithOptions, fetchStringWithOptions } from '../utils/Fetch';
+import { fetch, fetchString } from '../utils/Fetch';
 import { LOG } from '../utils/Logger';
 import { IEnvironment } from './IEnvironment';
 import { RequestOptions } from 'http';
@@ -50,7 +50,7 @@ export class EC2Environment implements IEnvironment {
         method: "PUT",
         headers: {[tokenRequestHeaderKey]: tokenRequestHeaderValue}
       }
-      this.token = await fetchStringWithOptions(options);
+      this.token = await fetchString(options);
     } catch (e) {
       LOG(e);
       return false;
@@ -63,7 +63,7 @@ export class EC2Environment implements IEnvironment {
         method: "GET",
         headers: {[metadataRequestTokenHeaderKey]: this.token}
       }
-      this.metadata = await fetchWithOptions<IEC2MetadataResponse>(metadataOptions);
+      this.metadata = await fetch<IEC2MetadataResponse>(metadataOptions);
       return !!this.metadata;
     } catch (e) {
       LOG(e);

--- a/src/environment/ECSEnvironment.ts
+++ b/src/environment/ECSEnvironment.ts
@@ -77,7 +77,8 @@ export class ECSEnvironment implements IEnvironment {
     }
 
     try {
-      this.metadata = await fetch<IECSMetadataResponse>(process.env.ECS_CONTAINER_METADATA_URI);
+      const options = new URL(process.env.ECS_CONTAINER_METADATA_URI);
+      this.metadata = await fetch<IECSMetadataResponse>(options);
       if (this.metadata) {
         this.metadata.FormattedImageName = formatImageName(this.metadata.Image);
         LOG(`Successfully collected ECS Container metadata.`);

--- a/src/environment/ECSEnvironment.ts
+++ b/src/environment/ECSEnvironment.ts
@@ -18,7 +18,7 @@ import { MetricsContext } from '../logger/MetricsContext';
 import { AgentSink } from '../sinks/AgentSink';
 import { ISink } from '../sinks/Sink';
 import { IEnvironment } from './IEnvironment';
-import { fetch } from '../utils/Fetch';
+import { fetchJSON } from '../utils/Fetch';
 import { LOG } from '../utils/Logger';
 import * as os from 'os';
 import { Constants } from '../Constants';
@@ -78,7 +78,7 @@ export class ECSEnvironment implements IEnvironment {
 
     try {
       const options = new URL(process.env.ECS_CONTAINER_METADATA_URI);
-      this.metadata = await fetch<IECSMetadataResponse>(options);
+      this.metadata = await fetchJSON<IECSMetadataResponse>(options);
       if (this.metadata) {
         this.metadata.FormattedImageName = formatImageName(this.metadata.Image);
         LOG(`Successfully collected ECS Container metadata.`);

--- a/src/environment/__tests__/ECSEnvironment.test.ts
+++ b/src/environment/__tests__/ECSEnvironment.test.ts
@@ -15,7 +15,7 @@ beforeEach(() => {
   config.serviceName = undefined;
   config.logGroupName = undefined;
   process.env = {
-    ECS_CONTAINER_METADATA_URI: faker.internet.ip(),
+    ECS_CONTAINER_METADATA_URI: faker.internet.url(),
   };
 });
 

--- a/src/environment/__tests__/ECSEnvironment.test.ts
+++ b/src/environment/__tests__/ECSEnvironment.test.ts
@@ -2,12 +2,12 @@ import * as faker from 'faker';
 import config from '../../config/Configuration';
 import { ECSEnvironment } from '../ECSEnvironment';
 import { MetricsContext } from '../../logger/MetricsContext';
-import { fetch } from '../../utils/Fetch';
+import { fetchJSON } from '../../utils/Fetch';
 
 import * as os from 'os';
 import { Constants } from '../../Constants';
 jest.mock('../../utils/Fetch', () => ({
-  fetch: jest.fn(),
+  fetchJSON: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -79,7 +79,7 @@ describe('configureContext()', () => {
     const expected = getRandomECSMetadata();
 
     // @ts-ignore
-    fetch.mockImplementation(() => expected);
+    fetchJSON.mockImplementation(() => expected);
     const env = new ECSEnvironment();
     await env.probe();
 
@@ -101,7 +101,7 @@ describe('configureContext()', () => {
     const expected = getRandomECSMetadata();
 
     // @ts-ignore
-    fetch.mockImplementation(() => expected);
+    fetchJSON.mockImplementation(() => expected);
     const env = new ECSEnvironment();
     await env.probe();
 
@@ -119,7 +119,7 @@ describe('configureContext()', () => {
     const expected = getRandomECSMetadata();
 
     // @ts-ignore
-    fetch.mockImplementation(() => expected);
+    fetchJSON.mockImplementation(() => expected);
     const env = new ECSEnvironment();
     await env.probe();
 
@@ -209,7 +209,7 @@ describe('getName()', () => {
     };
 
     // @ts-ignore
-    fetch.mockImplementation(() => metadata);
+    fetchJSON.mockImplementation(() => metadata);
     const env = new ECSEnvironment();
     await env.probe();
 
@@ -229,7 +229,7 @@ describe('getName()', () => {
     };
 
     // @ts-ignore
-    fetch.mockImplementation(() => metadata);
+    fetchJSON.mockImplementation(() => metadata);
     const env = new ECSEnvironment();
     await env.probe();
 
@@ -243,7 +243,7 @@ describe('getName()', () => {
   test('returns Unknown if image not available', async () => {
     // arrange
     // @ts-ignore
-    fetch.mockImplementation(() => {
+    fetchJSON.mockImplementation(() => {
       return {};
     });
     const env = new ECSEnvironment();

--- a/src/logger/MetricsContext.ts
+++ b/src/logger/MetricsContext.ts
@@ -89,7 +89,7 @@ export class MetricsContext {
     this.properties[key] = value;
   }
 
-  public setTimestamp(timestamp: Date | number) {
+  public setTimestamp(timestamp: Date | number): void {
     this.timestamp = timestamp;
     this.meta.Timestamp = MetricsContext.resolveMetaTimestamp(timestamp);
   }

--- a/src/utils/Fetch.ts
+++ b/src/utils/Fetch.ts
@@ -13,8 +13,7 @@
  * limitations under the License.
  */
 
-import * as http from 'http';
-import { RequestOptions } from 'http';
+import { IncomingMessage, RequestOptions, request as httpRequest} from 'http';
 
 const SOCKET_TIMEOUT = 1000;
 
@@ -23,10 +22,9 @@ const SOCKET_TIMEOUT = 1000;
  *
  * @param options - HTTP request options
  */
-const fetchStringWithOptions = (options: RequestOptions): Promise<string> => {
+const fetchString = (options: RequestOptions): Promise<string> => {
   return new Promise<string>((resolve, reject) => {
-    const request = http
-      .request(options, (response: http.IncomingMessage) => {
+    const request = httpRequest(options, (response: IncomingMessage) => {
         if (!response.statusCode) {
           reject(`Received undefined response status code from '${options.host}${options.path}'`);
           return;
@@ -69,20 +67,6 @@ const fetchStringWithOptions = (options: RequestOptions): Promise<string> => {
 }
 
 /**
- * Fetch JSON data from a remote HTTP endpoint and de-serialize to the provided type.
- * There are no guarantees the response will conform to the contract defined by T.
- * It is up to the consumer to ensure the provided T captures all possible response types
- * from the provided endpoint.
- *
- * @param url - currently only supports HTTP
- */
-const fetch = async <T>(url: string): Promise<T> => {
-  const options = new URL(url);
-  const responseString = await fetchStringWithOptions(options);
-  return JSON.parse(responseString);
-};
-
-/**
  * Fetch JSON data from a remote HTTP endpoint with the provided headers and de-serialize to the provided type.
  * There are no guarantees the response will conform to the contract defined by T.
  * It is up to the consumer to ensure the provided T captures all possible response types
@@ -90,9 +74,9 @@ const fetch = async <T>(url: string): Promise<T> => {
  *
  * @param options - HTTP request options
  */
-const fetchWithOptions = async <T>(options: RequestOptions): Promise<T> => {
-  const responseString = await fetchStringWithOptions(options);
+const fetch = async <T>(options: RequestOptions): Promise<T> => {
+  const responseString = await fetchString(options);
   return JSON.parse(responseString);
 }
 
-export { fetch, fetchWithOptions, fetchStringWithOptions };
+export { fetch, fetchString };

--- a/src/utils/Fetch.ts
+++ b/src/utils/Fetch.ts
@@ -13,17 +13,17 @@
  * limitations under the License.
  */
 
-import { IncomingMessage, RequestOptions, request as httpRequest} from 'http';
+import { IncomingMessage, RequestOptions, request as httpRequest } from 'http';
 
 const SOCKET_TIMEOUT = 1000;
 
 /**
- * Fetch a string from a remote HTTP endpoint with the provided headers.
+ * Fetch data from a remote HTTP endpoint with the provided headers.
  *
  * @param options - HTTP request options
  */
-const fetchString = (options: RequestOptions): Promise<string> => {
-  return new Promise<string>((resolve, reject) => {
+const fetch = (options: RequestOptions): Promise<Buffer> => {
+  return new Promise<Buffer>((resolve, reject) => {
     const request = httpRequest(options, (response: IncomingMessage) => {
         if (!response.statusCode) {
           reject(`Received undefined response status code from '${options.host}${options.path}'`);
@@ -46,8 +46,7 @@ const fetchString = (options: RequestOptions): Promise<string> => {
 
         response.on('end', () => {
           const buffer: Buffer = Buffer.concat(body, bodyBytes);
-          const responseString = buffer.toString();
-          resolve(responseString)
+          resolve(buffer)
         });
       })
       .on('error', (err: unknown) => {
@@ -67,6 +66,16 @@ const fetchString = (options: RequestOptions): Promise<string> => {
 }
 
 /**
+ * Fetch a string from a remote HTTP endpoint with the provided headers.
+ *
+ * @param options - HTTP request options
+ */
+const fetchString = async (options: RequestOptions): Promise<string> => {
+  const buffer = await fetch(options);
+  return buffer.toString();
+}
+
+/**
  * Fetch JSON data from a remote HTTP endpoint with the provided headers and de-serialize to the provided type.
  * There are no guarantees the response will conform to the contract defined by T.
  * It is up to the consumer to ensure the provided T captures all possible response types
@@ -74,9 +83,9 @@ const fetchString = (options: RequestOptions): Promise<string> => {
  *
  * @param options - HTTP request options
  */
-const fetch = async <T>(options: RequestOptions): Promise<T> => {
-  const responseString = await fetchString(options);
+const fetchJSON = async <T>(options: RequestOptions): Promise<T> => {
+  const responseString = await fetchString(options)
   return JSON.parse(responseString);
 }
 
-export { fetch, fetchString };
+export { fetch, fetchJSON, fetchString };

--- a/test/integ/agent/Dockerfile
+++ b/test/integ/agent/Dockerfile
@@ -2,7 +2,7 @@
 FROM public.ecr.aws/lts/ubuntu:20.04
 
 RUN apt-get update &&  \
-    apt-get install -y ca-certificates curl debian-keyring debian-archive-keyring && \
+    apt-get install -y ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -O https://amazon-cloud-watch-agent.s3.amazonaws.com/debian/amd64/1.237768.0/amazon-cloudwatch-agent.deb && \

--- a/test/integ/agent/Dockerfile
+++ b/test/integ/agent/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/lts/ubuntu:latest
 
 RUN apt-get update &&  \
-    apt-get install -y ca-certificates curl && \
+    apt-get install -y ca-certificates curl debian-keyring debian-archive-keyring && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -O https://amazon-cloud-watch-agent.s3.amazonaws.com/debian/amd64/1.237768.0/amazon-cloudwatch-agent.deb && \

--- a/test/integ/agent/Dockerfile
+++ b/test/integ/agent/Dockerfile
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/lts/ubuntu:latest
+# TODO: Fix the NO_PUBKEY error for jammy and update to use the :latest tag
+FROM public.ecr.aws/lts/ubuntu:20.04
 
 RUN apt-get update &&  \
     apt-get install -y ca-certificates curl debian-keyring debian-archive-keyring && \


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
IMDSv2 uses session authentication to retrieve EC2 instance metadata.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.