### PR TITLE
Correct dimension name length in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If the cardinality of a particular value is expected to be high, you should cons
 using `setProperty` instead.
 
 Requirements:
-- Length 1-255 characters
+- Length 1-250 characters
 - ASCII characters only
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If the cardinality of a particular value is expected to be high, you should cons
 using `setProperty` instead.
 
 Requirements:
-- Length 1-250 characters
+- Name length 1-250 characters
 - ASCII characters only
 
 Examples:
@@ -165,7 +165,7 @@ If the cardinality of a particular value is expected to be high, you should cons
 using `setProperty` instead.
 
 Requirements:
-- Length 1-250 characters
+- Name length 1-250 characters
 - ASCII characters only
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ If the cardinality of a particular value is expected to be high, you should cons
 using `setProperty` instead.
 
 Requirements:
-- Length 1-255 characters
+- Length 1-250 characters
 - ASCII characters only
 
 Examples:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Updates README to note correct dimension name length 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
