### PR TITLE
undo node_modules removal in pre-publish

### DIFF
--- a/bin/publish-package.sh
+++ b/bin/publish-package.sh
@@ -9,11 +9,11 @@ source $rootdir/bin/utils.sh
 new_version=$(cat package.json | jq '.version' --raw-output)
 echo "Deploying $new_version to NPM"
 
-rm -rf node_modules/
 # we need to do this so that eslint doesn't try to stat the directory
 # and blow up on too many symlinks
 rm -rf examples/agent/node_modules/
 rm -rf examples/ecs-firelens/node_modules/
+rm -rf examples/eks/node_modules/
 rm -rf examples/lambda/src/node_modules/
 rm -rf examples/testing/node_modules/
 

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -10,14 +10,3 @@ function check_exit() {
         exit $last_exit_code; 
     fi
 }
-
-function confirm() {
-    echo "Confirm [Yy]?"
-    read REPLY""
-    if [[ $REPLY =~ ^[Yy]$ ]]
-    then
-        # do dangerous stuff
-    else
-        exit 1
-    fi
-}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Deployment stage is failing due to `sh: jest: command not found`.
This change attempts to fix this issue by removing the command to delete `node_modules` in `publish-package.sh`.
This shouldn't have any effect on publishing since `npm publish` [ignores](https://docs.npmjs.com/cli/v8/commands/npm-publish) all files present in `.gitignore`.

Why wasn't this happening before? npm's `prepare` and `prepublishOnly` stages were unable to run in previous builds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
