### PR TITLE
Add validation for dimension values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/faker": "^4.1.5",
         "@types/jest": "^26.0.22",
         "@types/node": "^12.0.8",
+        "@types/validator": "^13.7.5",
         "@typescript-eslint/eslint-plugin": "^2.23.0",
         "@typescript-eslint/parser": "^2.23.0",
         "aws-sdk": "^2.551.0",
@@ -28,6 +29,7 @@
         "prettier": "^1.19.1",
         "ts-jest": "^26.5.4",
         "typescript": "^3.8.0",
+        "validator": "^13.7.0",
         "y18n": ">=4.0.1"
       },
       "engines": {
@@ -1338,6 +1340,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+      "dev": true
+    },
+    "node_modules/@types/validator": {
+      "version": "13.7.5",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.5.tgz",
+      "integrity": "sha512-9rQHeAqz6Jw3gDhttkmWetoriW5FPbxylv/6h6mXtaj2NKRcOvOmvfcswVdLVpbuy10NrO486K3lCoLgoIhiIA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -9913,6 +9921,15 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -11479,6 +11496,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+      "dev": true
+    },
+    "@types/validator": {
+      "version": "13.7.5",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.5.tgz",
+      "integrity": "sha512-9rQHeAqz6Jw3gDhttkmWetoriW5FPbxylv/6h6mXtaj2NKRcOvOmvfcswVdLVpbuy10NrO486K3lCoLgoIhiIA==",
       "dev": true
     },
     "@types/yargs": {
@@ -18122,6 +18145,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/faker": "^4.1.5",
     "@types/jest": "^26.0.22",
     "@types/node": "^12.0.8",
+    "@types/validator": "^13.7.5",
     "@typescript-eslint/eslint-plugin": "^2.23.0",
     "@typescript-eslint/parser": "^2.23.0",
     "aws-sdk": "^2.551.0",
@@ -52,6 +53,7 @@
     "prettier": "^1.19.1",
     "ts-jest": "^26.5.4",
     "typescript": "^3.8.0",
+    "validator": "^13.7.0",
     "y18n": ">=4.0.1"
   },
   "files": [

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -14,6 +14,9 @@
  */
 
 export enum Constants {
+  MAX_DIMENSION_NAME_LENGTH = 250,
+  MAX_DIMENSION_VALUE_LENGTH = 1024,
+
   MAX_DIMENSION_SET_SIZE = 30,
   DEFAULT_NAMESPACE = 'aws-embedded-metrics',
   MAX_METRICS_PER_EVENT = 100,

--- a/src/exceptions/InvalidDimensionError.ts
+++ b/src/exceptions/InvalidDimensionError.ts
@@ -1,0 +1,8 @@
+export class InvalidDimensionError extends Error {
+  constructor(msg: string) {
+    super(msg);
+
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, InvalidDimensionError.prototype);
+  }
+}

--- a/src/logger/MetricsContext.ts
+++ b/src/logger/MetricsContext.ts
@@ -15,11 +15,9 @@
 
 import Configuration from '../config/Configuration';
 import { LOG } from '../utils/Logger';
+import { Validator } from '../utils/Validator';
 import { MetricValues } from './MetricValues';
 import { Unit } from './Unit';
-import { Constants } from '../Constants';
-import { DimensionSetExceededError } from '../exceptions/DimensionSetExceededError';
-import { InvalidDimensionError } from '../exceptions/InvalidDimensionError';
 
 interface IProperties {
   [s: string]: unknown;
@@ -108,56 +106,13 @@ export class MetricsContext {
   }
 
   /**
-   * Validates dimension set.
-   * @see [CloudWatch Dimensions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html)
-   *
-   * @param dimensionSet
-   */
-  public static validateDimensionSet(dimensionSet: Record<string, string>): void {
-    if (Object.keys(dimensionSet).length > Constants.MAX_DIMENSION_SET_SIZE)
-      throw new DimensionSetExceededError(
-        `Maximum number of dimensions per dimension set allowed are ${Constants.MAX_DIMENSION_SET_SIZE}`,
-      );
-
-    // Validate dimension key and value are valid strings
-    Object.entries(dimensionSet).forEach(([key, value]) => {
-      dimensionSet[key] = String(value);
-
-      if (
-        !MetricsContext.isAscii(key) ||
-        key.trim().length == 0 ||
-        key.startsWith(':') ||
-        key.length > Constants.MAX_DIMENSION_NAME_LENGTH
-      ) {
-        throw new InvalidDimensionError(`Dimension value ${value} is invalid`);
-      }
-
-      if (
-        !MetricsContext.isAscii(value) ||
-        value.trim().length == 0 ||
-        value.length > Constants.MAX_DIMENSION_VALUE_LENGTH
-      ) {
-        throw new InvalidDimensionError(`Dimension value ${value} is invalid`);
-      }
-    });
-  }
-
-  /**
-   * Check if the string contains only ASCII characters.
-   * @param str string to check
-   */
-  public static isAscii(str: string): boolean {
-    return /^[\x20-\x7F]*$/.test(str);
-  }
-
-  /**
    * Adds a new set of dimensions. Any time a new dimensions set
    * is added, the set is first prepended by the default dimensions.
    *
    * @param dimensions
    */
   public putDimensions(incomingDimensionSet: Record<string, string>): void {
-    MetricsContext.validateDimensionSet(incomingDimensionSet);
+    Validator.validateDimensionSet(incomingDimensionSet);
 
     // Duplicate dimensions sets are removed before being added to the end of the collection.
     // This ensures the latest dimension key-value is used as a target member on the root EMF node.
@@ -184,7 +139,7 @@ export class MetricsContext {
   public setDimensions(dimensionSets: Array<Record<string, string>>): void {
     this.shouldUseDefaultDimensions = false;
 
-    dimensionSets.forEach(dimensionSet => MetricsContext.validateDimensionSet(dimensionSet));
+    dimensionSets.forEach(dimensionSet => Validator.validateDimensionSet(dimensionSet));
 
     this.dimensions = dimensionSets;
   }

--- a/src/logger/MetricsContext.ts
+++ b/src/logger/MetricsContext.ts
@@ -143,7 +143,7 @@ export class MetricsContext {
   }
 
   /**
-   * Check if the string contains only ascii characters
+   * Check if the string contains only ASCII characters.
    * @param str string to check
    */
   public static isAscii(str: string): boolean {

--- a/src/logger/MetricsContext.ts
+++ b/src/logger/MetricsContext.ts
@@ -126,7 +126,7 @@ export class MetricsContext {
       if (
         !MetricsContext.isAscii(key) ||
         key.trim().length == 0 ||
-        key.charAt(0) == ':' ||
+        key.startsWith(':') ||
         key.length > Constants.MAX_DIMENSION_NAME_LENGTH
       ) {
         throw new InvalidDimensionError(`Dimension value ${value} is invalid`);

--- a/src/logger/__tests__/MetricsContext.test.ts
+++ b/src/logger/__tests__/MetricsContext.test.ts
@@ -271,11 +271,11 @@ test('setDimensions checks all the dimension sets have less than 30 dimensions',
 test('adding dimensions validates them', () => {
   // arrange
   const context = MetricsContext.empty();
-  const dimensionNameWithInvalidAscii = { '🚀': 'value' };
+  const dimensionNameWithInvalidAscii = { '🚀': faker.random.word() };
   const dimensionValueWithInvalidAscii = { d1: 'مارك' };
-  const dimensionWithLongName = { ['a'.repeat(251)]: 'value' };
+  const dimensionWithLongName = { ['a'.repeat(251)]: faker.random.word() };
   const dimensionWithLongValue = { d1: 'a'.repeat(1025) };
-  const dimensionWithEmptyName = { ['']: 'value' };
+  const dimensionWithEmptyName = { ['']: faker.random.word() };
   const dimensionWithEmptyValue = { d1: '' };
   const dimensionNameStartWithColon = { ':d1': faker.random.word() };
 

--- a/src/logger/__tests__/MetricsContext.test.ts
+++ b/src/logger/__tests__/MetricsContext.test.ts
@@ -1,6 +1,7 @@
 import * as faker from 'faker';
 import { MetricsContext } from '../MetricsContext';
 import { DimensionSetExceededError } from '../../exceptions/DimensionSetExceededError';
+import { InvalidDimensionError } from '../../exceptions/InvalidDimensionError';
 
 test('can set property', () => {
   // arrange
@@ -20,7 +21,7 @@ test('can set property', () => {
 test('setDimensions allows 30 dimensions', () => {
   // arrange
   const context = MetricsContext.empty();
-  const numOfDimensions = 30
+  const numOfDimensions = 30;
   const expectedDimensionSet = getDimensionSet(numOfDimensions);
 
   // act
@@ -31,7 +32,6 @@ test('setDimensions allows 30 dimensions', () => {
 });
 
 test('putDimension adds key to dimension and sets the dimension as a property', () => {
-
   // arrange
   const context = MetricsContext.empty();
   const dimension = faker.random.word();
@@ -251,25 +251,59 @@ test('createCopyWithContext copies shouldUseDefaultDimensions', () => {
 test('putDimensions checks the dimension set length', () => {
   // arrange
   const context = MetricsContext.empty();
-  const numOfDimensions = 33
+  const numOfDimensions = 33;
 
   expect(() => {
-    context.putDimensions(getDimensionSet(numOfDimensions))
+    context.putDimensions(getDimensionSet(numOfDimensions));
   }).toThrow(DimensionSetExceededError);
 });
 
 test('setDimensions checks all the dimension sets have less than 30 dimensions', () => {
   // arrange
   const context = MetricsContext.empty();
-  const numOfDimensions = 33
+  const numOfDimensions = 33;
 
   expect(() => {
-    context.setDimensions([getDimensionSet(numOfDimensions)])
+    context.setDimensions([getDimensionSet(numOfDimensions)]);
   }).toThrow(DimensionSetExceededError);
 });
 
+test('validateDimensionSet validates dimension set', () => {
+  // arrange
+  const dimensionNameWithInvalidAscii = { '🚀': 'value' };
+  const dimensionValueWithInvalidAscii = { d1: 'مارك' };
+  const dimensionWithLongName = { ['a'.repeat(251)]: 'value' };
+  const dimensionWithLongValue = { d1: 'a'.repeat(1025) };
+  const dimensionWithEmptyName = { ['']: 'value' };
+  const dimensionWithEmptyValue = { d1: '' };
+  const dimensionNameStartWithColon = { ':d1': faker.random.word() };
+
+  // act
+  expect(() => {
+    MetricsContext.validateDimensionSet(dimensionNameWithInvalidAscii);
+  }).toThrow(InvalidDimensionError);
+  expect(() => {
+    MetricsContext.validateDimensionSet(dimensionValueWithInvalidAscii);
+  }).toThrow(InvalidDimensionError);
+  expect(() => {
+    MetricsContext.validateDimensionSet(dimensionWithLongName);
+  }).toThrow(InvalidDimensionError);
+  expect(() => {
+    MetricsContext.validateDimensionSet(dimensionWithLongValue);
+  }).toThrow(InvalidDimensionError);
+  expect(() => {
+    MetricsContext.validateDimensionSet(dimensionWithEmptyName);
+  }).toThrow(InvalidDimensionError);
+  expect(() => {
+    MetricsContext.validateDimensionSet(dimensionWithEmptyValue);
+  }).toThrow(InvalidDimensionError);
+  expect(() => {
+    MetricsContext.validateDimensionSet(dimensionNameStartWithColon);
+  }).toThrow(InvalidDimensionError);
+});
+
 const getDimensionSet = (numOfDimensions: number) => {
-  const dimensionSet:Record<string, string> = {}
+  const dimensionSet: Record<string, string> = {};
 
   for (let i = 0; i < numOfDimensions; i++) {
     const expectedKey = `${i}`;
@@ -277,4 +311,4 @@ const getDimensionSet = (numOfDimensions: number) => {
   }
 
   return dimensionSet;
-}
+};

--- a/src/logger/__tests__/MetricsContext.test.ts
+++ b/src/logger/__tests__/MetricsContext.test.ts
@@ -268,8 +268,9 @@ test('setDimensions checks all the dimension sets have less than 30 dimensions',
   }).toThrow(DimensionSetExceededError);
 });
 
-test('validateDimensionSet validates dimension set', () => {
+test('adding dimensions validates them', () => {
   // arrange
+  const context = MetricsContext.empty();
   const dimensionNameWithInvalidAscii = { '🚀': 'value' };
   const dimensionValueWithInvalidAscii = { d1: 'مارك' };
   const dimensionWithLongName = { ['a'.repeat(251)]: 'value' };
@@ -280,25 +281,25 @@ test('validateDimensionSet validates dimension set', () => {
 
   // act
   expect(() => {
-    MetricsContext.validateDimensionSet(dimensionNameWithInvalidAscii);
+    context.putDimensions(dimensionNameWithInvalidAscii);
   }).toThrow(InvalidDimensionError);
   expect(() => {
-    MetricsContext.validateDimensionSet(dimensionValueWithInvalidAscii);
+    context.setDimensions([dimensionValueWithInvalidAscii]);
   }).toThrow(InvalidDimensionError);
   expect(() => {
-    MetricsContext.validateDimensionSet(dimensionWithLongName);
+    context.putDimensions(dimensionWithLongName);
   }).toThrow(InvalidDimensionError);
   expect(() => {
-    MetricsContext.validateDimensionSet(dimensionWithLongValue);
+    context.setDimensions([dimensionWithLongValue]);
   }).toThrow(InvalidDimensionError);
   expect(() => {
-    MetricsContext.validateDimensionSet(dimensionWithEmptyName);
+    context.putDimensions(dimensionWithEmptyName);
   }).toThrow(InvalidDimensionError);
   expect(() => {
-    MetricsContext.validateDimensionSet(dimensionWithEmptyValue);
+    context.setDimensions([dimensionWithEmptyValue]);
   }).toThrow(InvalidDimensionError);
   expect(() => {
-    MetricsContext.validateDimensionSet(dimensionNameStartWithColon);
+    context.putDimensions(dimensionNameStartWithColon);
   }).toThrow(InvalidDimensionError);
 });
 

--- a/src/serializers/LogSerializer.ts
+++ b/src/serializers/LogSerializer.ts
@@ -48,8 +48,6 @@ export class LogSerializer implements ISerializer {
         throw new DimensionSetExceededError(errMsg);
       }
 
-      // Stringify and remove non-ascii characeters (allow only 0x20-0x7E)
-      keys.forEach(key => (dimensionSet[key] = String(dimensionSet[key]).replace(/[^\x20-\x7F]/g, '')));
 
       dimensionKeys.push(keys);
       dimensionProperties = { ...dimensionProperties, ...dimensionSet };

--- a/src/serializers/LogSerializer.ts
+++ b/src/serializers/LogSerializer.ts
@@ -38,21 +38,21 @@ export class LogSerializer implements ISerializer {
     const dimensionKeys: string[][] = [];
     let dimensionProperties = {};
 
-    context.getDimensions().forEach(d => {
-      // we can only take the first 9 defined dimensions
-      // the reason we do this in the serializer is because
-      // it is possible that other sinks or formats can
-      // support more dimensions
-      // in the future it may make sense to introduce a higher-order
-      // representation for sink-specific validations
-      const keys = Object.keys(d);
+    context.getDimensions().forEach(dimensionSet => {
+      const keys = Object.keys(dimensionSet);
+
       if (keys.length > Constants.MAX_DIMENSION_SET_SIZE) {
-        const errMsg = `Maximum number of dimensions allowed are ${Constants.MAX_DIMENSION_SET_SIZE}.` +
-        `Account for default dimensions if not using set_dimensions.`;
-        throw new DimensionSetExceededError(errMsg)
+        const errMsg =
+          `Maximum number of dimensions allowed are ${Constants.MAX_DIMENSION_SET_SIZE}.` +
+          `Account for default dimensions if not using set_dimensions.`;
+        throw new DimensionSetExceededError(errMsg);
       }
+
+      // Stringify and remove non-ascii characeters (allow only 0x20-0x7E)
+      keys.forEach(key => (dimensionSet[key] = String(dimensionSet[key]).replace(/[^\x20-\x7F]/g, '')));
+
       dimensionKeys.push(keys);
-      dimensionProperties = { ...dimensionProperties, ...d };
+      dimensionProperties = { ...dimensionProperties, ...dimensionSet };
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/serializers/__tests__/LogSerializer.test.ts
+++ b/src/serializers/__tests__/LogSerializer.test.ts
@@ -180,7 +180,7 @@ test('cannot serialize more than 30 dimensions', () => {
 
   // assert
   expect(() => {
-    serializer.serialize(context)
+    serializer.serialize(context);
   }).toThrow(DimensionSetExceededError);
 });
 
@@ -188,6 +188,47 @@ const assertJsonEquality = (resultJson: string, expectedObj: any) => {
   const actual = JSON.parse(resultJson);
   expect(actual).toStrictEqual(expectedObj);
 };
+
+test('remove non-ascii characters from dimension values', () => {
+  // arrange
+  const key = faker.random.word();
+  const value = '¡éè©µascii🚀♞∑';
+  const expectedValue = 'ascii';
+  const dimensions: any = {};
+  const expectedDimensions: any = {};
+  expectedDimensions[key] = expectedValue;
+  dimensions[key] = value;
+
+  const expected: any = { ...getEmptyPayload(), ...expectedDimensions };
+  expected._aws.CloudWatchMetrics[0].Dimensions.push([key]);
+
+  const context = getContext();
+  context.putDimensions(dimensions);
+
+  // act
+  const resultJson = serializer.serialize(context)[0];
+
+  // assert
+  assertJsonEquality(resultJson, expected);
+});
+
+test('convert dimension values to strings', () => {
+  // arrange
+  const key = faker.random.word();
+  const value = faker.random.number();
+  const expectedValue = String(value);
+  const dimensions: any = {};
+  dimensions[key] = value;
+
+  const context = getContext();
+  context.putDimensions(dimensions);
+
+  // act
+  const resultJson = serializer.serialize(context)[0];
+
+  // assert
+  expect(JSON.parse(resultJson)[key]).toStrictEqual(expectedValue);
+});
 
 const getEmptyPayload = () => {
   return Object.assign(

--- a/src/serializers/__tests__/LogSerializer.test.ts
+++ b/src/serializers/__tests__/LogSerializer.test.ts
@@ -189,47 +189,6 @@ const assertJsonEquality = (resultJson: string, expectedObj: any) => {
   expect(actual).toStrictEqual(expectedObj);
 };
 
-test('remove non-ascii characters from dimension values', () => {
-  // arrange
-  const key = faker.random.word();
-  const value = '¡éè©µascii🚀♞∑';
-  const expectedValue = 'ascii';
-  const dimensions: any = {};
-  const expectedDimensions: any = {};
-  expectedDimensions[key] = expectedValue;
-  dimensions[key] = value;
-
-  const expected: any = { ...getEmptyPayload(), ...expectedDimensions };
-  expected._aws.CloudWatchMetrics[0].Dimensions.push([key]);
-
-  const context = getContext();
-  context.putDimensions(dimensions);
-
-  // act
-  const resultJson = serializer.serialize(context)[0];
-
-  // assert
-  assertJsonEquality(resultJson, expected);
-});
-
-test('convert dimension values to strings', () => {
-  // arrange
-  const key = faker.random.word();
-  const value = faker.random.number();
-  const expectedValue = String(value);
-  const dimensions: any = {};
-  dimensions[key] = value;
-
-  const context = getContext();
-  context.putDimensions(dimensions);
-
-  // act
-  const resultJson = serializer.serialize(context)[0];
-
-  // assert
-  expect(JSON.parse(resultJson)[key]).toStrictEqual(expectedValue);
-});
-
 const getEmptyPayload = () => {
   return Object.assign(
     {},

--- a/src/utils/Validator.ts
+++ b/src/utils/Validator.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import validator from 'validator';
+import { Constants } from '../Constants';
+import { DimensionSetExceededError } from '../exceptions/DimensionSetExceededError';
+import { InvalidDimensionError } from '../exceptions/InvalidDimensionError';
+
+export class Validator {
+  /**
+   * Validates dimension set.
+   * @see [CloudWatch Dimensions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html)
+   *
+   * @param dimensionSet
+   * @throws {DimensionSetExceededError} Dimension set must not exceed 30 dimensions.
+   * @throws {InvalidDimensionError} Dimension name and value must be valid.
+   */
+  public static validateDimensionSet(dimensionSet: Record<string, string>): void {
+    // Validates dimension set length
+    if (Object.keys(dimensionSet).length > Constants.MAX_DIMENSION_SET_SIZE)
+      throw new DimensionSetExceededError(
+        `Maximum number of dimensions per dimension set allowed are ${Constants.MAX_DIMENSION_SET_SIZE}`,
+      );
+
+    // Validate dimension key and value
+    Object.entries(dimensionSet).forEach(([key, value]) => {
+      dimensionSet[key] = value = String(value);
+
+      if (!validator.isAscii(key)) {
+        throw new InvalidDimensionError(`Dimension key ${key} has invalid characters`);
+      }
+      if (!validator.isAscii(value)) {
+        throw new InvalidDimensionError(`Dimension value ${value} has invalid characters`);
+      }
+
+      if (key.trim().length == 0) {
+        throw new InvalidDimensionError(`Dimension key ${key} must include at least one non-whitespace character`);
+      }
+
+      if (value.trim().length == 0) {
+        throw new InvalidDimensionError(`Dimension value ${value} must include at least one non-whitespace character`);
+      }
+
+      if (key.length > Constants.MAX_DIMENSION_NAME_LENGTH) {
+        throw new InvalidDimensionError(
+          `Dimension key ${key} must not exceed maximum length ${Constants.MAX_DIMENSION_NAME_LENGTH}`,
+        );
+      }
+
+      if (value.length > Constants.MAX_DIMENSION_VALUE_LENGTH) {
+        throw new InvalidDimensionError(
+          `Dimension value ${value} must not exceed maximum length ${Constants.MAX_DIMENSION_VALUE_LENGTH}`,
+        );
+      }
+
+      if (key.startsWith(':')) {
+        throw new InvalidDimensionError(`Dimension key ${key} cannot start with ':'`);
+      }
+    });
+  }
+}


### PR DESCRIPTION
*Issue #, if available:* #68

Related issues:
* https://github.com/awslabs/aws-embedded-metrics-python/issues/88
* https://github.com/awslabs/aws-embedded-metrics-java/issues/112
* https://github.com/awslabs/aws-embedded-metrics-dotnet/issues/35

*Description of changes:*
Add function to strip non-ascii characters and stringify numbers for dimension values.

[UPDATE] Instead of silently dropping non-compliant characters, the client will now throw an error if an invalid dimension is found according to specifications [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html) (breaking change).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
