### PR TITLE
High Resolution Metrics Support

### DIFF
--- a/examples/agent/index.js
+++ b/examples/agent/index.js
@@ -1,9 +1,19 @@
-const { metricScope, Unit } = require('aws-embedded-metrics');
+const { metricScope, Unit, StorageResolution} = require('aws-embedded-metrics');
 
 const doWork = metricScope(metrics => async event => {
   metrics.putDimensions({ Operation: 'Agent' });
-  metrics.putMetric('ExampleMetric', 100, Unit.Milliseconds);
+  metrics.putMetric('ExampleMetricHigh', 100, Unit.Milliseconds);
+  metrics.putMetric('ExampleMetricHigh', 101, Unit.Milliseconds,StorageResolution.High);
+  metrics.setProperty('RequestId', '422b1569-16f6-4a03-b8f0-fe3fd9b100f8');
+});
+
+const dodummyWork = metricScope(metrics => async event => {
+  metrics.putDimensions({ Operation: 'Agent' });
+  metrics.putMetric('ExampleMetricHigh', 102, Unit.Milliseconds, StorageResolution.High);
+  metrics.putMetric('ExampleMetricHigh', 103, Unit.Milliseconds, StorageResolution.High);
   metrics.setProperty('RequestId', '422b1569-16f6-4a03-b8f0-fe3fd9b100f8');
 });
 
 doWork();
+// dodummyWork();
+// doWork();

--- a/examples/agent/index.js
+++ b/examples/agent/index.js
@@ -2,18 +2,10 @@ const { metricScope, Unit, StorageResolution} = require('aws-embedded-metrics');
 
 const doWork = metricScope(metrics => async event => {
   metrics.putDimensions({ Operation: 'Agent' });
-  metrics.putMetric('ExampleMetricHigh', 100, Unit.Milliseconds);
-  metrics.putMetric('ExampleMetricHigh', 101, Unit.Milliseconds,StorageResolution.High);
-  metrics.setProperty('RequestId', '422b1569-16f6-4a03-b8f0-fe3fd9b100f8');
-});
-
-const dodummyWork = metricScope(metrics => async event => {
-  metrics.putDimensions({ Operation: 'Agent' });
-  metrics.putMetric('ExampleMetricHigh', 102, Unit.Milliseconds, StorageResolution.High);
-  metrics.putMetric('ExampleMetricHigh', 103, Unit.Milliseconds, StorageResolution.High);
+  metrics.putMetric('ExampleMetric', 100, Unit.Milliseconds);
+  metrics.putMetric('ExampleMetric', 101, Unit.Milliseconds);
+  metrics.putMetric('ExampleHighResolutionMetric', 11, Unit.Milliseconds, StorageResolution.High);
   metrics.setProperty('RequestId', '422b1569-16f6-4a03-b8f0-fe3fd9b100f8');
 });
 
 doWork();
-// dodummyWork();
-// doWork();

--- a/src/logger/MetricValues.ts
+++ b/src/logger/MetricValues.ts
@@ -14,14 +14,17 @@
  */
 
 import { Unit } from '..';
+import { StorageResolution } from './StorageResolution';
 
 export class MetricValues {
   public values: number[];
   public unit: string;
+  public storageResolution: StorageResolution;
 
-  constructor(value: number, unit?: Unit | string) {
+  constructor(value: number, unit?: Unit | string, storageResolution?: StorageResolution) {
     this.values = [value];
     this.unit = unit || 'None';
+    this.storageResolution = storageResolution || StorageResolution.Standard;
   }
 
   /**

--- a/src/logger/MetricsContext.ts
+++ b/src/logger/MetricsContext.ts
@@ -17,6 +17,7 @@ import Configuration from '../config/Configuration';
 import { LOG } from '../utils/Logger';
 import { validateNamespace, validateTimestamp, validateDimensionSet, validateMetric } from '../utils/Validator';
 import { MetricValues } from './MetricValues';
+import { StorageResolution } from './StorageResolution';
 import { Unit } from './Unit';
 
 interface IProperties {
@@ -41,6 +42,7 @@ export class MetricsContext {
   private defaultDimensions: Record<string, string>;
   private shouldUseDefaultDimensions = true;
   private timestamp: Date | number | undefined;
+  private metricNameAndResolutionMap: Map<string, StorageResolution> = new Map<string, StorageResolution>();
 
   /**
    * Constructor used to create child instances.
@@ -180,14 +182,14 @@ export class MetricsContext {
     });
   }
 
-  public putMetric(key: string, value: number, unit?: Unit | string): void {
-    validateMetric(key, value, unit);
+  public putMetric(key: string, value: number, unit?: Unit | string, storageResolution?:StorageResolution): void {
+    validateMetric(key, value, unit, storageResolution, this.metricNameAndResolutionMap);
 
     const currentMetric = this.metrics.get(key);
     if (currentMetric) {
       currentMetric.addValue(value);
     } else {
-      this.metrics.set(key, new MetricValues(value, unit));
+      this.metrics.set(key, new MetricValues(value, unit, storageResolution));
     }
   }
 

--- a/src/logger/MetricsLogger.ts
+++ b/src/logger/MetricsLogger.ts
@@ -18,6 +18,7 @@ import { EnvironmentProvider } from '../environment/EnvironmentDetector';
 import { IEnvironment } from '../environment/IEnvironment';
 import { MetricsContext } from './MetricsContext';
 import { Unit } from './Unit';
+import { StorageResolution } from './StorageResolution';
 
 /**
  * An async metrics logger.
@@ -124,9 +125,10 @@ export class MetricsLogger {
    * @param key
    * @param value
    * @param unit
+   * @param storageResolution
    */
-  public putMetric(key: string, value: number, unit?: Unit | string): MetricsLogger {
-    this.context.putMetric(key, value, unit);
+  public putMetric(key: string, value: number, unit?: Unit | string, storageResolution?: StorageResolution): MetricsLogger {
+    this.context.putMetric(key, value, unit, storageResolution);
     return this;
   }
 

--- a/src/logger/StorageResolution.ts
+++ b/src/logger/StorageResolution.ts
@@ -13,13 +13,7 @@
  * limitations under the License.
  */
 
-export { MetricsLogger } from './logger/MetricsLogger';
-export { ConsoleSink as LocalSink } from './sinks/ConsoleSink';
-export { AgentSink } from './sinks/AgentSink';
-export { metricScope } from './logger/MetricScope';
-export { createMetricsLogger } from './logger/MetricsLoggerFactory';
-export { Unit } from './logger/Unit';
-export { StorageResolution } from './logger/StorageResolution';
-
-import Configuration from './config/Configuration';
-export { Configuration };
+export enum StorageResolution {
+  High = 1,
+  Standard = 60,
+}

--- a/src/logger/__tests__/MetricsContext.test.ts
+++ b/src/logger/__tests__/MetricsContext.test.ts
@@ -203,6 +203,23 @@ test('putMetric uses None unit if not provided', () => {
   expect(metricDatum.unit).toBe(expectedUnit);
 });
 
+test('putMetric uses Standard storageResolution if not provided', () => {
+  // arrange
+  const context = MetricsContext.empty();
+  const expectedKey = faker.random.word();
+  const expectedValue = faker.datatype.number();
+  const expectedStorageResolution = 60; //TODO_M remove this after metric validation
+
+  // act
+  context.putMetric(expectedKey, expectedValue);
+
+  // assert
+  const metricDatum: any = context.metrics.get(expectedKey);
+  expect(metricDatum).toBeTruthy();
+  expect(metricDatum.values).toStrictEqual([expectedValue]);
+  expect(metricDatum.storageResolution).toBe(expectedStorageResolution);
+});
+
 test('createCopyWithContext creates new instance', () => {
   // arrange
   const context = MetricsContext.empty();

--- a/src/logger/__tests__/MetricsLogger.test.ts
+++ b/src/logger/__tests__/MetricsLogger.test.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { Unit } from '../..';
+import { Unit, StorageResolution } from '../..';
 import { TestSink } from '../../../test/utils/TestSink';
 import Configuration from '../../config/Configuration';
 import { EnvironmentProvider } from '../../environment/EnvironmentDetector';
@@ -7,6 +7,7 @@ import { IEnvironment } from '../../environment/IEnvironment';
 import { ISink } from '../../sinks/Sink';
 import { MetricsContext } from '../MetricsContext';
 import { MetricsLogger } from '../MetricsLogger';
+import { InvalidMetricError } from '../../exceptions/InvalidMetricError';
 
 const createSink = (forceAcceptRejects = false) => new TestSink(forceAcceptRejects);
 const createEnvironment = (sink: ISink) => {
@@ -115,6 +116,56 @@ describe('successful', () => {
     const actualMetric = sink.events[0].metrics.get(expectedKey);
     expect(actualMetric).toBeTruthy();
     expect(actualMetric!.unit).toBe(expectedUnit);
+  });
+
+  test('can put high resolution metric with unit', async () => {
+    // arrange
+    const expectedKey = faker.random.word();
+    const expectedValue = faker.datatype.number();
+    const expectedUnit = Unit.Bits;
+    const expectedStorageResolution = StorageResolution.High;
+
+    // act
+    logger.putMetric(expectedKey, expectedValue, expectedUnit, expectedStorageResolution);
+    await logger.flush();
+
+    // assert
+    expect(sink.events).toHaveLength(1);
+    const actualMetric = sink.events[0].metrics.get(expectedKey);
+    expect(actualMetric).toBeTruthy();
+    expect(actualMetric!.unit).toBe(expectedUnit);
+    expect(actualMetric!.storageResolution).toBe(expectedStorageResolution);
+  });
+
+  test('can put high resolution metric without unit', async () => {
+    // arrange
+    const expectedKey = faker.random.word();
+    const expectedValue = faker.datatype.number();
+    const expectedStorageResolution = StorageResolution.High;
+
+    // act
+    logger.putMetric(expectedKey, expectedValue, undefined, expectedStorageResolution);
+    await logger.flush();
+
+    // assert
+    expect(sink.events).toHaveLength(1);
+    const actualMetric = sink.events[0].metrics.get(expectedKey);
+    expect(actualMetric).toBeTruthy();
+    expect(actualMetric!.storageResolution).toBe(expectedStorageResolution);
+  });
+
+  test('can put metric with same key and different resolution in separate flushes', async () => {
+    const expectedKey = 'MetricName';
+    const expectedValue = faker.datatype.number();
+    const expectedUnit = 'None';
+  
+    // assert
+   expect(async () => {
+     logger.putMetric(expectedKey, expectedValue,expectedUnit,StorageResolution.Standard);
+     await logger.flush();
+     logger.putMetric(expectedKey, expectedValue,expectedUnit,StorageResolution.High);
+     await logger.flush();
+   }).not.toThrow(InvalidMetricError);
   });
 
   test('can put dimension', async () => {

--- a/src/serializers/LogSerializer.ts
+++ b/src/serializers/LogSerializer.ts
@@ -17,6 +17,7 @@ import { MaxHeap } from '@datastructures-js/heap';
 import { Constants } from '../Constants';
 import { DimensionSetExceededError } from '../exceptions/DimensionSetExceededError';
 import { MetricsContext } from '../logger/MetricsContext';
+import { StorageResolution } from '../logger/StorageResolution';
 import { ISerializer } from './Serializer';
 
 interface MetricProgress {
@@ -38,7 +39,7 @@ export class LogSerializer implements ISerializer {
     const dimensionKeys: string[][] = [];
     let dimensionProperties = {};
 
-    context.getDimensions().forEach(dimensionSet => {
+    context.getDimensions().forEach((dimensionSet) => {
       const keys = Object.keys(dimensionSet);
 
       if (keys.length > Constants.MAX_DIMENSION_SET_SIZE) {
@@ -89,7 +90,7 @@ export class LogSerializer implements ISerializer {
       Array.from(context.metrics, ([key, value]) => {
         return { name: key, numLeft: value.values.length };
       }),
-      metric => metric.numLeft,
+      (metric) => metric.numLeft,
     );
     let processedMetrics: MetricProgress[] = [];
 
@@ -109,8 +110,18 @@ export class LogSerializer implements ISerializer {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         currentBody[metricProgress.name] = metricValue;
         // eslint-disable-next-line
-        currentBody._aws.CloudWatchMetrics[0].Metrics.push({ Name: metricProgress.name, Unit: metric.unit });
-
+        if (metric.storageResolution === StorageResolution.Standard) {
+          currentBody._aws.CloudWatchMetrics[0].Metrics.push({
+            Name: metricProgress.name,
+            Unit: metric.unit,
+          });
+        } else {
+          currentBody._aws.CloudWatchMetrics[0].Metrics.push({
+            Name: metricProgress.name,
+            Unit: metric.unit,
+            StorageResolution: metric.storageResolution,
+          });
+        }
         metricProgress.numLeft -= Constants.MAX_VALUES_PER_METRIC;
         if (metricProgress.numLeft > 0) {
           processedMetrics.push(metricProgress);
@@ -119,7 +130,7 @@ export class LogSerializer implements ISerializer {
         if (hasMaxMetrics() || remainingMetrics.isEmpty()) {
           serializeCurrentBody();
           // inserts these metrics back in the heap to be processed in the next iteration.
-          processedMetrics.forEach(processingMetric => remainingMetrics.insert(processingMetric));
+          processedMetrics.forEach((processingMetric) => remainingMetrics.insert(processingMetric));
           processedMetrics = [];
         }
       }

--- a/src/serializers/LogSerializer.ts
+++ b/src/serializers/LogSerializer.ts
@@ -109,19 +109,15 @@ export class LogSerializer implements ISerializer {
               metric.values.slice(startIndex, startIndex + Constants.MAX_VALUES_PER_METRIC);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         currentBody[metricProgress.name] = metricValue;
-        // eslint-disable-next-line
-        if (metric.storageResolution === StorageResolution.Standard) {
-          currentBody._aws.CloudWatchMetrics[0].Metrics.push({
-            Name: metricProgress.name,
-            Unit: metric.unit,
-          });
-        } else {
-          currentBody._aws.CloudWatchMetrics[0].Metrics.push({
-            Name: metricProgress.name,
-            Unit: metric.unit,
-            StorageResolution: metric.storageResolution,
-          });
+        let metricBody: {[key: string]: any} = {
+          Name: metricProgress.name,
+          Unit: metric.unit,
         }
+        if (metric.storageResolution === StorageResolution.High)
+        {
+          metricBody.StorageResolution = StorageResolution.High;
+        }
+        currentBody._aws.CloudWatchMetrics[0].Metrics.push(metricBody);
         metricProgress.numLeft -= Constants.MAX_VALUES_PER_METRIC;
         if (metricProgress.numLeft > 0) {
           processedMetrics.push(metricProgress);

--- a/src/serializers/__tests__/LogSerializer.test.ts
+++ b/src/serializers/__tests__/LogSerializer.test.ts
@@ -3,6 +3,7 @@ import { Constants } from '../../Constants';
 import { MetricsContext } from '../../logger/MetricsContext';
 import { LogSerializer } from '../LogSerializer';
 import { DimensionSetExceededError } from '../../exceptions/DimensionSetExceededError';
+import { Unit, StorageResolution } from '../..';
 
 test('serializes dimensions', () => {
   // arrange
@@ -78,6 +79,55 @@ test('serializes metrics with multiple datapoints', () => {
   const context = getContext();
   context.putMetric(expectedKey, expectedValues[0]);
   context.putMetric(expectedKey, expectedValues[1]);
+
+  // act
+  const resultJson = serializer.serialize(context)[0];
+
+  // assert
+  assertJsonEquality(resultJson, expected);
+});
+
+test('serialize high resolution metrics', () => {
+  // arrange
+  const expectedKey = faker.random.word();
+  const expectedValue = faker.datatype.number();
+  const expectedUnit = Unit.Bits;
+  const expectedStorageResolution = StorageResolution.High;
+  const expectedMetricDefinition = {
+    Name: expectedKey,
+    Unit: 'Bits',
+    StorageResolution:1
+  };
+  const expected: any = { ...getEmptyPayload() };
+  expected[expectedKey] = expectedValue;
+  expected._aws.CloudWatchMetrics[0].Metrics.push(expectedMetricDefinition);
+
+  const context = getContext();
+  context.putMetric(expectedKey, expectedValue, expectedUnit,expectedStorageResolution);
+
+  // act
+  const resultJson = serializer.serialize(context)[0];
+
+  // assert
+  assertJsonEquality(resultJson, expected);
+});
+
+test('serialize standard resolution metrics', () => {
+  // arrange
+  const expectedKey = faker.random.word();
+  const expectedValue = faker.datatype.number();
+  const expectedUnit = Unit.Bits;
+  const expectedStorageResolution = StorageResolution.Standard;
+  const expectedMetricDefinition = {
+    Name: expectedKey,
+    Unit: 'Bits'
+  };
+  const expected: any = { ...getEmptyPayload() };
+  expected[expectedKey] = expectedValue;
+  expected._aws.CloudWatchMetrics[0].Metrics.push(expectedMetricDefinition);
+
+  const context = getContext();
+  context.putMetric(expectedKey, expectedValue, expectedUnit,expectedStorageResolution);
 
   // act
   const resultJson = serializer.serialize(context)[0];


### PR DESCRIPTION
*Description of changes:*

Added support for High Resolution Metrics. Customers can specify an optional property - storageResolution of the metrics in putMetric() call. If resolution is not specified, metrics will be emitted with standard resolution.
Added UTs and modified integration tests for the changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
