### PR TITLE
Update canary deploy script

### DIFF
--- a/bin/deploy-canary.sh
+++ b/bin/deploy-canary.sh
@@ -17,8 +17,7 @@ ECS_SERVICE_NAME=emf-canary-$EMF_LANGUAGE-service
 ECR_ENDPOINT=$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
 ECR_REMOTE=$ECR_ENDPOINT/$IMAGE_NAME
 
-mkdir $NODE_MODULES_PATH
-rm -rf $NODE_MODULES_PATH/aws-embedded-metrics
+cp -r $LIB_PATH/node_modules $NODE_MODULES_PATH/
 cp -r $LIB_PATH/lib $NODE_MODULES_PATH/aws-embedded-metrics
 cp -r $LIB_PATH/package.json $NODE_MODULES_PATH/aws-embedded-metrics/package.json
 


### PR DESCRIPTION
*Description of changes:*
ECS soak test is failing with error message
```
Error: Cannot find module '@datastructures-js/heap'
```

This PR updates the deploy script to copy all `node_module` dependencies to the docker image.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
