### PR TITLE
Replace : character with / in logGroupName because : is invalid

### DIFF
--- a/src/environment/ECSEnvironment.ts
+++ b/src/environment/ECSEnvironment.ts
@@ -60,6 +60,11 @@ const formatImageName = (imageName: string): string => {
   return imageName;
 };
 
+// logGroupName must satisfy regular expression pattern: [\\.\\-_/#A-Za-z0-9]+
+const formatLogGroupName = (logGroupName: string): string => {
+  return logGroupName.replace(":", "/");
+}
+
 export class ECSEnvironment implements IEnvironment {
   private sink: ISink | undefined;
   private metadata: IECSMetadataResponse | undefined;
@@ -114,7 +119,9 @@ export class ECSEnvironment implements IEnvironment {
       return '';
     }
 
-    return config.logGroupName || this.getName();
+    const logGroupName = config.logGroupName || this.getName()
+
+    return formatLogGroupName(logGroupName);
   }
 
   public configureContext(context: MetricsContext): void {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, the [`logGroupName` can be created from the result of `formatImageName`](https://github.com/awslabs/aws-embedded-metrics-node/blob/master/src/environment/ECSEnvironment.ts#L102). However, `formatImageName` can return a string that contains the `:`character, which is not valid in a `logGroupName`.

CloudWatch returns the following error:

```
"InvalidParameterException: 1 validation error detected: Value '<formatImageName>' at 'logGroupName' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\.\\-_/#A-Za-z0-9]+"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.