### PR TITLE
update import statements for downstream esm compatibility

### DIFF
--- a/src/sinks/AgentSink.ts
+++ b/src/sinks/AgentSink.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import url = require('url');
+import url from 'url';
 
 import Configuration from '../config/Configuration';
 import { MetricsContext } from '../logger/MetricsContext';

--- a/src/sinks/ConsoleSink.ts
+++ b/src/sinks/ConsoleSink.ts
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import { Console } from 'console';
 import { MetricsContext } from '../logger/MetricsContext';
 import { LogSerializer } from '../serializers/LogSerializer';
 import { ISerializer } from '../serializers/Serializer';
@@ -25,7 +24,6 @@ import { ISink } from './Sink';
  */
 export class ConsoleSink implements ISink {
   public readonly name: string = 'ConsoleSink';
-
   private serializer: ISerializer;
   public readonly console: Console;
   private static readonly AWS_LAMBDA_LOG_FORMAT = 'AWS_LAMBDA_LOG_FORMAT';
@@ -35,7 +33,9 @@ export class ConsoleSink implements ISink {
 
     // To avoid escaping EMF when using Lambda JSON log format we need to use Console() instead of console
     this.console =
-      process.env[ConsoleSink.AWS_LAMBDA_LOG_FORMAT] === 'JSON' ? new Console(process.stdout, process.stderr) : console;
+      process.env[ConsoleSink.AWS_LAMBDA_LOG_FORMAT] === 'JSON'
+        ? new console.Console(process.stdout, process.stderr)
+        : console;
   }
 
   public accept(context: MetricsContext): Promise<void> {


### PR DESCRIPTION
*Issue #, if available:*
When compiling consuming packages to ESM using tsc, the following errors appeared at runtime 

Error: Dynamic require of "console" is not supported
Error: Dynamic require of "url" is not supported

package.json in consuming 
```
{
  "type": "module"
}
```

tsconfig in consuming package: 
```
"jsx": "react",
"rootDir": "./src",
"noUnusedLocals": true,
"noUnusedParameters": true,
"noImplicitReturns": true,
"forceConsistentCasingInFileNames": true,
"skipLibCheck": true,
"target": "es2022",
"esModuleInterop": true,
"allowJs": true,
"resolveJsonModule": true,
"moduleDetection": "force",
"isolatedModules": true,
"strict": true,
"noUncheckedIndexedAccess": true,
"module": "NodeNext",
"outDir": "dist",
"sourceMap": true,
"verbatimModuleSyntax": true,
"declaration": true,
"lib": ["es2022"]
```

*Description of changes:*

- removes the import url = require('url') and adds import url from 'url'
- removes the import of Console and changes the constructor to new console.Console leveraging the global variable at runtime 

Thanks for taking time to review! :) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
