### PR TITLE
changed dockerhub cw agent image to use ecr image

### DIFF
--- a/test/canary/agent/container-definitions.json
+++ b/test/canary/agent/container-definitions.json
@@ -25,7 +25,7 @@
   },
   {
     "name": "cloudwatch-agent",
-    "image": "amazon/cloudwatch-agent:latest",
+    "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changed cloudwatch agent dockerhub image to use ECR version instead, this is to be consistent with this PR: https://github.com/awslabs/aws-embedded-metrics-java/pull/164

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
